### PR TITLE
Breaking Change: fix #29 & process recent api deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ client.changeUserLeverage({leverage: 4, symbol: 'ETHUSD'})
     console.log(result);
   })
   .catch(err => {
-    console.error(error);
+    console.error(err);
   });
 ```
 
@@ -57,23 +57,23 @@ const ws = new WebsocketClient({key: API_KEY, secret: PRIVATE_KEY});
 ws.subscribe(['position', 'execution', 'trade']);
 ws.subscribe('kline.BTCUSD.1m');
 
-ws.on('open', function() {
+ws.on('open', () => {
   console.log('connection open');
 });
 
-ws.on('update', function(message) {
+ws.on('update', message => {
   console.log('update', message);
 });
 
-ws.on('response', function(response) {
+ws.on('response', response => {
   console.log('response', response);
 });
 
-ws.on('close', function() {
+ws.on('close', () => {
   console.log('connection closed');
 });
 
-ws.on('error', function(err) {
+ws.on('error', err => {
   console.error('ERR', err);
 });
 ```

--- a/README.md
+++ b/README.md
@@ -5,20 +5,27 @@
 
 [1]: https://www.npmjs.com/package/bybit-api
 
-An light node.js wrapper for the Bybit Cryptocurrency Derivative exchange API. Forked & adapted from [@pxtrn/bybit-api](https://github.com/pixtron/bybit-api).
+A production-ready Node.js connector for the Bybit APIs and WebSockets.
 
 ## Installation
 `npm install --save bybit-api`
 
 ## Usage
-Create API credentials at bybit (obviously you need to be logged in):
+Create API credentials at Bybit
 - [Livenet](https://bybit.com/app/user/api-management?affiliate_id=9410&language=en-US&group_id=0&group_type=1)
 - [Testnet](https://testnet.bybit.com/app/user/api-management)
 
-## Documentation
-Most of the documentation is in [Bybit's official API docs](https://bybit-exchange.github.io/docs/inverse/#t-introduction). Most of this library's methods accept objects that directly correspond to expectations from Bybit's API docs.
+## Issues & Discussion
+- Issues? Check the [issues tab](https://github.com/tiagosiebler/bybit-api/issues).
+- Discuss & collaborate with other node devs? Join our [Node.js Algo Traders](https://t.me/nodetraders) engineering community on telegram.
 
-### Rest client
+## Documentation
+Most methods accept JS objects. These can be populated using parameters specified by Bybit's API documentation.
+- [Bybit API Inverse Documentation](https://bybit-exchange.github.io/docs/inverse/#t-introduction).
+- [Bybit API Linear Documentation (not supported yet)](https://bybit-exchange.github.io/docs/linear/#t-introduction)
+
+### Inverse Contracts
+#### Rest client
 ```javascript
 const {RestClient} = require('bybit-api');
 
@@ -36,9 +43,9 @@ client.changeUserLeverage({leverage: 4, symbol: 'ETHUSD'})
   });
 ```
 
-See rest client [api docs](./doc/rest-client.md) for further information.
+See inverse [rest-client.js](./master/lib/rest-client.js) for further information.
 
-### Websocket client
+#### Websocket client
 ```javascript
 const {WebsocketClient} = require('bybit-api');
 
@@ -70,8 +77,7 @@ ws.on('error', function(err) {
   console.error('ERR', err);
 });
 ```
-
-See websocket client [api docs](./doc/websocket-client.md) for further information.
+See inverse [websocket-client.js](./master/lib/websocket-client.js) & [ws api docs](./doc/websocket-client.md) for further information.
 
 ### Customise Logging
 Pass a custom logger which supports the log methods `silly`, `debug`, `notice`, `info`, `warning` and `error`, or override methods from the default logger as desired:
@@ -82,20 +88,11 @@ const { RestClient, WebsocketClient, DefaultLogger } = require('bybit-api');
 // Disable all logging on the silly level
 DefaultLogger.silly = () => {};
 
-const API_KEY = 'xxx';
-const PRIVATE_KEY = 'yyy';
-
-const ws = new WebsocketClient({key: API_KEY, secret: PRIVATE_KEY}, DefaultLogger);
+const ws = new WebsocketClient({key: 'xxx', secret: 'yyy'}, DefaultLogger);
 ```
 
 ## Contributions & Thanks
 ### Donations
-#### pixtron
-This library was started by @pixtron. If this library helps you to trade better on bybit, feel free to donate a coffee to @pixtron:
-- BTC `1Fh1158pXXudfM6ZrPJJMR7Y5SgZUz4EdF`
-- ETH `0x21aEdeC53ab7593b77C9558942f0c9E78131e8d7`
-- LTC `LNdHSVtG6UWsriMYLJR3qLdfVNKwJ6GSLF`
-
 #### tiagosiebler
 If you found this project interesting or useful, create accounts with my referral links:
 - [Bybit](https://www.bybit.com/en-US/register?affiliate_id=9410&language=en-US&group_id=0&group_type=1)
@@ -104,6 +101,12 @@ If you found this project interesting or useful, create accounts with my referra
 Or buy me a coffee using any of these:
 - BTC: `1C6GWZL1XW3jrjpPTS863XtZiXL1aTK7Jk`
 - ETH (ERC20): `0xd773d8e6a50758e1ada699bb6c4f98bb4abf82da`
+
+#### pixtron
+The original library was started by @pixtron. If this library helps you to trade better on bybit, feel free to donate a coffee to @pixtron:
+- BTC `1Fh1158pXXudfM6ZrPJJMR7Y5SgZUz4EdF`
+- ETH `0x21aEdeC53ab7593b77C9558942f0c9E78131e8d7`
+- LTC `LNdHSVtG6UWsriMYLJR3qLdfVNKwJ6GSLF`
 
 ### Contributions & Pull Requests
 Contributions are encouraged, I will review any incoming pull requests. See the issues tab for todo items.

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -6,6 +6,7 @@
   "exclude": [
       "node_modules",
       "**/node_modules/*",
-      "coverage"
+      "coverage",
+      "doc"
   ]
 }

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -1,6 +1,4 @@
-
 const assert = require('assert');
-
 const RequestWrapper = require('./util/requestWrapper');
 
 module.exports = class RestClient {
@@ -54,6 +52,17 @@ module.exports = class RestClient {
     assert(params.order_id || params.order_link_id, 'Parameter order_id OR order_link_id is required');
     assert(params.symbol, 'Parameter symbol is required');
 
+    return await this.request.post('v2/private/order/replace', params);
+  }
+
+  /**
+   * @deprecated use replaceActiveOrder()
+   */
+  async replaceActiveOrderOld(params) {
+    assert(params, 'No params passed');
+    assert(params.order_id || params.order_link_id, 'Parameter order_id OR order_link_id is required');
+    assert(params.symbol, 'Parameter symbol is required');
+
     return await this.request.post('open-api/order/replace', params);
   }
 
@@ -71,6 +80,24 @@ module.exports = class RestClient {
     assert(params.symbol, 'Parameter symbol is required');
     assert(params.order_type, 'Parameter order_type is required');
     assert(params.qty, 'Parameter qty is required');
+    assert(params.base_price, 'Parameter base_price is required');
+    assert(params.stop_px, 'Parameter stop_px is required');
+    assert(params.time_in_force, 'Parameter time_in_force is required');
+
+    if (params.order_type === 'Limit') assert(params.price, 'Parameter price is required for limit orders');
+
+    return await this.request.post('v2/private/stop-order/create', params);
+  }
+
+  /**
+   * @deprecated use placeConditionalOrder
+   */
+  async placeConditionalOrderOld(params) {
+    assert(params, 'No params passed');
+    assert(params.side, 'Parameter side is required');
+    assert(params.symbol, 'Parameter symbol is required');
+    assert(params.order_type, 'Parameter order_type is required');
+    assert(params.qty, 'Parameter qty is required');
     assert(params.time_in_force, 'Parameter time_in_force is required');
     assert(params.base_price, 'Parameter base_price is required');
     assert(params.stop_px, 'Parameter stop_px is required');
@@ -81,10 +108,28 @@ module.exports = class RestClient {
   }
 
   async getConditionalOrder(params) {
+    assert(params.symbol, 'Parameter symbol is required');
+    return await this.request.get('v2/private/stop-order/list', params);
+  }
+
+  /**
+   * @deprecated use placeConditionalOrder
+   */
+  async getConditionalOrderOld(params) {
     return await this.request.get('open-api/stop-order/list', params);
   }
 
   async cancelConditionalOrder(params) {
+    assert(params, 'No params passed');
+    assert(params.stop_order_id || params.order_link_id, 'Parameter stop_order_id OR order_link_id is required');
+
+    return await this.request.post('v2/private/stop-order/cancel', params);
+  }
+
+  /**
+   * @deprecated use cancelConditionalOrder
+   */
+  async cancelConditionalOrderOld(params) {
     assert(params, 'No params passed');
     assert(params.stop_order_id, 'Parameter stop_order_id is required');
 
@@ -100,6 +145,17 @@ module.exports = class RestClient {
 
   async replaceConditionalOrder(params) {
     assert(params, 'No params passed');
+    assert(params.stop_order_id || params.order_link_id, 'Parameter stop_order_id OR order_link_id is required');
+    assert(params.symbol, 'Parameter symbol is required');
+
+    return await this.request.post('v2/private/stop-order/replace', params);
+  }
+
+  /**
+   * @deprecated use replaceConditionalOrder
+   */
+  async replaceConditionalOrderOld(params) {
+    assert(params, 'No params passed');
     assert(params.stop_order_id, 'Parameter stop_order_id is required');
     assert(params.symbol, 'Parameter symbol is required');
 
@@ -114,8 +170,15 @@ module.exports = class RestClient {
     return await this.request.get('v2/private/stop-order', params);
   }
 
+  /**
+   * @deprecated use getPosition() instead
+   */
   async getUserLeverage() {
     return await this.request.get('user/leverage');
+  }
+
+  async getPosition(params) {
+    return await this.request.get('v2/private/position/list', params);
   }
 
   async changeUserLeverage(params) {
@@ -126,13 +189,9 @@ module.exports = class RestClient {
     return await this.request.post('user/leverage/save', params);
   }
 
-  async getPosition(params) {
-    assert(params, 'No params passed');
-    assert(params.symbol, 'Parameter symbol is required');
-
-    return await this.request.get('v2/private/position/list', params);
-  }
-
+  /**
+   * @deprecated use getPosition() instead
+   */
   async getPositions() {
     return await this.request.get('position/list');
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A production-ready Node.js connector for the Bybit APIs and WebSockets",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bybit-api",
   "version": "1.2.1",
-  "description": "A node.js wrapper for the Bybit Cryptocurrency Derivative exchange APIs",
+  "description": "A production-ready Node.js connector for the Bybit APIs and WebSockets",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -18,13 +18,15 @@
     "rest api",
     "inverse",
     "nodejs",
+    "node",
     "trading",
     "cryptocurrency",
-    "bitcoin"
+    "bitcoin",
+    "best"
   ],
-  "author": "Stefan Aebischer <os@pixtron.ch> (https://pixtron.ch)",
+  "author": "Tiago Siebler (https://github.com/tiagosiebler)",
   "contributors": [
-    "Tiago Siebler (https://github.com/tiagosiebler)"
+    "Stefan Aebischer <os@pixtron.ch> (https://pixtron.ch)"
   ],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
- [x] **Breaking Change**: Update/replace deprecated APIs. Old/original APIs can be found with functionName*Old* but will be removed when officially deprecated by bybit. See Bybit's announcement for a full list of deprecated/abandoned inverse APIs and recommended alternatives: https://bybit-exchange.github.io/docs/inverse/#2020-11-10
- [x] Fix #29 

Review Checklist
- [x] Manual tests on testnet
- [x] Manual tests on livenet

Notification from bybit:
```

Dear valued Bybit trader:


Thank you for trading with Bybit. 

To enhance the efficiency and stability of the API endpoints, Bybit will upgrade our REST and WebSocket API on November 30, 2020. The following adjustments will be made:


1. The following WebSocket topics will be removed from service:

a) orderBook25 (please replace with topic orderBookL2_25 or
orderBook_200.100ms)
b) kline (please replace with topic klineV2)
c) instrument (please replace with topic instrument_info)


2. The following REST API will be upgraded. The older version of API will be deprecated on December 10, 2020. Effective immediately, the rate limit will be reduced by half before being completely removed from service on December 17, 2020. Hence, please use the following new REST API endpoints:

a) /open-api/order/list (please replace with /v2/private/order/list)
b) /open-api/stop-order/create (please replace with /v2/private/stop-order/create)
c) /open-api/stop-order/list (please replace with /v2/private/stop-order/list)
d) /open-api/stop-order/cancel (please replace with /v2/private/stop-order/cancel)
e) /open-api/order/replace (please replace with /v2/private/order/replace)
f) /open-api/stop-order/replace (please replace with /v2/private/stop-order/replace)
g) /open-api/order/create (please replace with /v2/private/order/create)
 h) /open-api/order/cancel (please replace with /v2/private/order/cancel)
i) /position/list (please replace with /v2/private/position/list)
j) /user/leverage (please replace with /v2/private/position/list)

All updates can also be found here: https://bybit-exchange.github.io/docs/inverse/#2020-11-10

Please update your program promptly to enjoy uninterrupted trading activities. The latest version is required for SDK users. For Python SDK users, please kindly update to v0.2.10 or above. 


Thank you for your understanding and cooperation. If you have any questions, please contact us at IT@bybit.com.
```