### PR TITLE
fix(#21): add pass-thru options and URL override for WebSocket client. Update docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,35 @@ const {WebsocketClient} = require('bybit-api');
 const API_KEY = 'xxx';
 const PRIVATE_KEY = 'yyy';
 
-const ws = new WebsocketClient({key: API_KEY, secret: PRIVATE_KEY});
+const wsConfig = {
+  key: API_KEY,
+  secret: PRIVATE_KEY,
+
+  // The following parameters are optional:
+
+  // defaults to false == testnet. set to true for livenet.
+  // livenet: true
+
+  // override which URL to use for websocket connections
+  // wsUrl: 'wss://stream.bytick.com/realtime'
+
+  // how often to check (in ms) that WS connection is still alive
+  // pingInterval: 10000,
+
+  // how long to wait (in ms) before deciding the connection should be terminated & reconnected
+  // pongTimeout: 1000,
+
+  // how long to wait before attempting to reconnect (in ms) after connection is closed
+  // reconnectTimeout: 500,
+
+  // config options sent to RestClient (used for time sync). See RestClient docs.
+  // restOptions: { },
+
+  // config for axios to pass to RestClient. E.g for proxy support
+  // requestOptions: { }
+};
+
+const ws = new WebsocketClient(wsConfig);
 
 ws.subscribe(['position', 'execution', 'trade']);
 ws.subscribe('kline.BTCUSD.1m');

--- a/lib/websocket-client.js
+++ b/lib/websocket-client.js
@@ -1,5 +1,4 @@
-const {EventEmitter} = require('events');
-
+const { EventEmitter } = require('events');
 const WebSocket = require('ws');
 
 const defaultLogger = require('./logger');
@@ -35,7 +34,7 @@ module.exports = class WebsocketClient extends EventEmitter {
       ...options
     };
 
-    this.client = new RestClient(null, null, this.options.livenet);
+    this.client = new RestClient(null, null, this.options.livenet, this.options.restOptions, this.options.requestOptions);
     this._subscriptions = new Set();
 
     this._connect();
@@ -65,12 +64,19 @@ module.exports = class WebsocketClient extends EventEmitter {
     this.ws && this.ws.close();
   }
 
+  _getWsUrl() {
+    if (this.options.wsUrl) {
+      return this.options.wsUrl;
+    }
+    return wsUrls[this.options.livenet ? 'livenet' : 'testnet'];
+  }
+
   async _connect() {
     try {
       if (this.readyState === READY_STATE_INITIAL) this.readyState = READY_STATE_CONNECTING;
 
       const authParams = await this._authenticate();
-      const url = wsUrls[this.options.livenet ? 'livenet' : 'testnet'] + authParams;
+      const url = this._getWsUrl() + authParams;
 
       this.ws = new WebSocket(url);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A production-ready Node.js connector for the Bybit APIs and WebSockets",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Fixes #21 
- Allows proxy use via axios configuration, when using websockets.
- Allows override of websocket URL using `wsUrl` option. See readme.