### PR TITLE
v1.2.4: optional params in wallet balance fetch (fixes #36)

### DIFF
--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -121,6 +121,7 @@ module.exports = class RestClient {
 
   async cancelConditionalOrder(params) {
     assert(params, 'No params passed');
+    assert(params.symbol, 'Parameter symbol is required');
     assert(params.stop_order_id || params.order_link_id, 'Parameter stop_order_id OR order_link_id is required');
 
     return await this.request.post('v2/private/stop-order/cancel', params);
@@ -198,8 +199,8 @@ module.exports = class RestClient {
 
   async changePositionMargin(params) {
     assert(params, 'No params passed');
-    assert(params.margin, 'Parameter margin is required');
     assert(params.symbol, 'Parameter symbol is required');
+    assert(params.margin, 'Parameter margin is required');
 
     return await this.request.post('position/change-position-margin', params);
   }
@@ -224,8 +225,6 @@ module.exports = class RestClient {
   }
 
   async getWalletBalance(params) {
-    assert(params, 'No params passed');
-    assert(params.coin, 'Parameter coin is required');
     return await this.request.get('v2/private/wallet/balance', params);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "A production-ready Node.js connector for the Bybit APIs and WebSockets",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- getWalletBalance() does not require any parameters (fixes #36).
- cancelConditionalOrder() requires symbol parameter.