### PR TITLE
fix set leverage for resetting back to cross (value == 0)

### DIFF
--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -184,8 +184,11 @@ module.exports = class RestClient {
 
   async changeUserLeverage(params) {
     assert(params, 'No params passed');
-    assert(params.leverage, 'Parameter leverage is required');
     assert(params.symbol, 'Parameter symbol is required');
+
+    if (typeof params.leverage === 'undefined') {
+      throw new Error('Parameter leverage is required');
+    }
 
     return await this.request.post('user/leverage/save', params);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "A production-ready Node.js connector for the Bybit APIs and WebSockets",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The assert was throwing when the value was set to 0. This prevented setting leverage back to cross.