### PR TITLE
Updated getActiveOrder to use v2 endpoint

### DIFF
--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -29,7 +29,7 @@ module.exports = class RestClient {
   }
 
   async getActiveOrder(params) {
-    return await this.request.get('open-api/order/list', params);
+    return await this.request.get('v2/private/order/list', params);
   }
 
   async cancelActiveOrder(params) {


### PR DESCRIPTION
the old endpoint is dead on testnet and produces errors