### PR TITLE
Support for Linear (USDT) on the updated typescript version.

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -42,6 +42,8 @@ jobs:
 
       - run: npm ci
         if: steps.version-updated.outputs.has-updated
+      - run: npm run clean
+        if: steps.version-updated.outputs.has-updated
       - run: npm run build
         if: steps.version-updated.outputs.has-updated
       - run: npm publish

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ A production-ready Node.js connector for the Bybit APIs and WebSockets, with Typ
 
 ## Issues & Discussion
 - Issues? Check the [issues tab](https://github.com/tiagosiebler/bybit-api/issues).
-- RestClient not defined? With the recent addition of LinearClient, we renamed RestClient to InverseClient. Change all old references.
 - Discuss & collaborate with other node devs? Join our [Node.js Algo Traders](https://t.me/nodetraders) engineering community on telegram.
+- `'bybit-api' has no exported member 'RestClient'`: use `InverseClient` instead of `RestClient`
 
 ## Documentation
 Most methods accept JS objects. These can be populated using parameters specified by Bybit's API documentation.

--- a/README.md
+++ b/README.md
@@ -39,13 +39,10 @@ Build a bundle using webpack:
 The bundle can be found in `dist/`. Altough usage should be largely consistent, smaller differences will exist. Documentation is still TODO.
 
 ### Inverse Contracts
-#### Rest client
-```javascript
-const { RestClient } = require('bybit-api');
+Since inverse and linear (USDT) contracts don't use the exact same APIs, the REST abstractions are split into two modules. To use the inverse REST APIs, import the `InverseClient`:
 
-const API_KEY = 'xxx';
-const PRIVATE_KEY = 'yyy';
-const useLivenet = false;
+```javascript
+const { InverseClient } = require('bybit-api');
 
 const restInverseOptions = {
   // override the max size of the request window (in ms)
@@ -68,7 +65,11 @@ const restInverseOptions = {
   parse_exceptions?: boolean;
 };
 
-const client = new RestClient(
+const API_KEY = 'xxx';
+const PRIVATE_KEY = 'yyy';
+const useLivenet = false;
+
+const client = new InverseClient(
   API_KEY,
   PRIVATE_KEY,
 
@@ -88,9 +89,67 @@ client.changeUserLeverage({leverage: 4, symbol: 'ETHUSD'})
   });
 ```
 
-See inverse [rest-client.ts](./src/rest-client.ts) for further information.
+See inverse [inverse-client.ts](./src/inverse-client.ts) for further information.
 
-#### Websocket client
+### Linear Contracts
+To use the Linear (USDT) REST APIs, import the `LinearClient`:
+
+```javascript
+const { LinearClient } = require('bybit-api');
+
+const restInverseOptions = {
+  // override the max size of the request window (in ms)
+  recv_window?: number;
+
+  // how often to sync time drift with bybit servers
+  sync_interval_ms?: number | string;
+
+  // Default: false. Disable above sync mechanism if true.
+  disable_time_sync?: boolean;
+
+  // Default: false. If true, we'll throw errors if any params are undefined
+  strict_param_validation?: boolean;
+
+  // Optionally override API protocol + domain
+  // e.g 'https://api.bytick.com'
+  baseUrl?: string;
+
+  // Default: true. whether to try and post-process request exceptions.
+  parse_exceptions?: boolean;
+};
+
+const API_KEY = 'xxx';
+const PRIVATE_KEY = 'yyy';
+const useLivenet = false;
+
+const client = new LinearClient(
+  API_KEY,
+  PRIVATE_KEY,
+
+  // optional, uses testnet by default. Set to 'true' to use livenet.
+  useLivenet,
+
+  // restInverseOptions,
+  // requestLibraryOptions
+);
+
+client.changeUserLeverage({leverage: 4, symbol: 'ETHUSD'})
+  .then(result => {
+    console.log(result);
+  })
+  .catch(err => {
+    console.error(err);
+  });
+```
+
+### WebSockets
+
+Inverse & linear WebSockets can be used via a shared `WebsocketClient`.
+
+Note: to use the linear websockets, pass "linear: true" in the constructor options when instancing the `WebsocketClient`.
+
+To connect to both linear and inverse websockets, make two instances of the WebsocketClient:
+
 ```javascript
 const { WebsocketClient } = require('bybit-api');
 
@@ -123,7 +182,7 @@ const wsConfig = {
   // config options sent to RestClient (used for time sync). See RestClient docs.
   // restOptions: { },
 
-  // config for axios to pass to RestClient. E.g for proxy support
+  // config for axios used for HTTP requests. E.g for proxy support
   // requestOptions: { }
 
   // override which URL to use for websocket connections

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A production-ready Node.js connector for the Bybit APIs and WebSockets, with Typ
 
 ## Issues & Discussion
 - Issues? Check the [issues tab](https://github.com/tiagosiebler/bybit-api/issues).
-- RestClient not defined? With our recent addition of LinearClient, we renamed RestClient to InverseClient. Change all references to RestClient.
+- RestClient not defined? With the recent addition of LinearClient, we renamed RestClient to InverseClient. Change all old references.
 - Discuss & collaborate with other node devs? Join our [Node.js Algo Traders](https://t.me/nodetraders) engineering community on telegram.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -101,19 +101,21 @@ const wsConfig = {
   key: API_KEY,
   secret: PRIVATE_KEY,
 
-  // The following parameters are optional:
+  /*
+    The following parameters are optional:
+  */
 
-  // defaults to false == testnet. set to true for livenet.
+  // defaults to false == testnet. Set to true for livenet.
   // livenet: true
 
-  // override which URL to use for websocket connections
-  // wsUrl: 'wss://stream.bytick.com/realtime'
-
-  // how often to check (in ms) that WS connection is still alive
-  // pingInterval: 10000,
+  // defaults to fase == inverse. Set to true for linear (USDT) trading.
+  // linear: true
 
   // how long to wait (in ms) before deciding the connection should be terminated & reconnected
   // pongTimeout: 1000,
+
+  // how often to check (in ms) that WS connection is still alive
+  // pingInterval: 10000,
 
   // how long to wait before attempting to reconnect (in ms) after connection is closed
   // reconnectTimeout: 500,
@@ -123,45 +125,60 @@ const wsConfig = {
 
   // config for axios to pass to RestClient. E.g for proxy support
   // requestOptions: { }
+
+  // override which URL to use for websocket connections
+  // wsUrl: 'wss://stream.bytick.com/realtime'
 };
 
 const ws = new WebsocketClient(wsConfig);
 
+// subscribe to multiple topics at once
 ws.subscribe(['position', 'execution', 'trade']);
+
+// and/or subscribe to individual topics on demand
 ws.subscribe('kline.BTCUSD.1m');
 
-ws.on('open', () => {
-  console.log('connection open');
+// Listen to events coming from websockets. This is the primary data source
+ws.on('update', data => {
+  console.log('update', data);
 });
 
-ws.on('update', message => {
-  console.log('update', message);
+// Optional: Listen to websocket connection open event (automatic after subscribing to one or more topics)
+ws.on('open', ({ wsKey, event }) => {
+  console.log('connection open for websocket with ID: ' + wsKey);
 });
 
+// Optional: Listen to responses to websocket queries (e.g. the response after subscribing to a topic)
 ws.on('response', response => {
   console.log('response', response);
 });
 
+// Optional: Listen to connection close event. Unexpected connection closes are automatically reconnected.
 ws.on('close', () => {
   console.log('connection closed');
 });
 
+// Optional: Listen to raw error events.
+// Note: responses to invalid topics are currently only sent in the "response" event.
 ws.on('error', err => {
   console.error('ERR', err);
 });
 ```
-See inverse [websocket-client.ts](./src/websocket-client.ts) for further information.
+See [websocket-client.ts](./src/websocket-client.ts) for further information.
 
 ### Customise Logging
 Pass a custom logger which supports the log methods `silly`, `debug`, `notice`, `info`, `warning` and `error`, or override methods from the default logger as desired:
 
 ```js
-const { RestClient, WebsocketClient, DefaultLogger } = require('bybit-api');
+const { WebsocketClient, DefaultLogger } = require('bybit-api');
 
 // Disable all logging on the silly level
 DefaultLogger.silly = () => {};
 
-const ws = new WebsocketClient({key: 'xxx', secret: 'yyy'}, DefaultLogger);
+const ws = new WebsocketClient(
+  { key: 'xxx', secret: 'yyy' },
+  DefaultLogger
+);
 ```
 
 ## Contributions & Thanks

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A production-ready Node.js connector for the Bybit APIs and WebSockets, with Typ
 ## Documentation
 Most methods accept JS objects. These can be populated using parameters specified by Bybit's API documentation.
 - [Bybit API Inverse Documentation](https://bybit-exchange.github.io/docs/inverse/#t-introduction).
-- [Bybit API Linear Documentation (not supported yet)](https://bybit-exchange.github.io/docs/linear/#t-introduction)
+- [Bybit API Linear Documentation](https://bybit-exchange.github.io/docs/linear/#t-introduction)
 
 ## Structure
 This project uses typescript. Resources are stored in 3 key structures:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A production-ready Node.js connector for the Bybit APIs and WebSockets, with Typ
 
 ## Issues & Discussion
 - Issues? Check the [issues tab](https://github.com/tiagosiebler/bybit-api/issues).
+- RestClient not defined? With our recent addition of LinearClient, we renamed RestClient to InverseClient. Change all references to RestClient.
 - Discuss & collaborate with other node devs? Join our [Node.js Algo Traders](https://t.me/nodetraders) engineering community on telegram.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ const client = new LinearClient(
   // requestLibraryOptions
 );
 
-client.changeUserLeverage({leverage: 4, symbol: 'ETHUSD'})
+client.changeUserLeverage({leverage: 4, symbol: 'ETHUSDT'})
   .then(result => {
     console.log(result);
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rm -rf lib dist",
-    "buildclean": "npm run clean && npm run build",
     "build": "tsc",
+    "build:clean": "npm run clean && npm run build",
     "build:watch": "npm run clean && tsc --watch",
     "pack": "webpack --config webpack/webpack.config.js",
-    "prepublish": "npm run build",
+    "prepublish": "npm run build:clean",
     "betapublish": "npm publish --tag beta"
   },
   "author": "Tiago Siebler (https://github.com/tiagosiebler)",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
     "webpack-bundle-analyzer": "^4.1.0",
     "webpack-cli": "^4.2.0"
   },
-  "browser": {
-    "crypto": false
-  },
   "keywords": [
     "bybit",
     "api",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rm -rf lib dist",
-    "prebuild": "npm run clean",
+    "buildclean": "npm run clean && npm run build",
     "build": "tsc",
+    "build:watch": "npm run clean && tsc --watch",
     "pack": "webpack --config webpack/webpack.config.js",
     "prepublish": "npm run build",
     "betapublish": "npm publish --tag beta"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "webpack-bundle-analyzer": "^4.1.0",
     "webpack-cli": "^4.2.0"
   },
+  "browser": {
+    "crypto": false
+  },
   "keywords": [
     "bybit",
     "api",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
-export * from './rest-client';
+export * from './inverse-client';
+export * from './linear-client';
 export * from './websocket-client';
 export * from './logger';

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -122,7 +122,9 @@ export class InverseClient extends SharedEndpoints {
    *
    */
   
-  //Active Orders
+	/**
+   * Active orders
+   */
 
   placeActiveOrder(orderRequest: {
     side: string;
@@ -182,7 +184,9 @@ export class InverseClient extends SharedEndpoints {
     return this.requestWrapper.get('v2/private/order', params);
   }
   
-  //Conditional Orders
+	/**
+   * Conditional orders
+   */
 
   placeConditionalOrder(params: {
     side: string;
@@ -243,7 +247,9 @@ export class InverseClient extends SharedEndpoints {
     return this.requestWrapper.get('v2/private/stop-order', params);
   }
   
-  //Position
+	/**
+   * Position
+   */
 
   /**
    * @deprecated use getPosition() instead
@@ -319,7 +325,9 @@ export class InverseClient extends SharedEndpoints {
     return this.requestWrapper.get('v2/private/trade/closed-pnl/list', params);
   }
 
-  //Risk Limit
+	/**
+   * Risk Limit
+   */
   
   getRiskLimitList(): GenericAPIResponse {
     return this.requestWrapper.get('open-api/wallet/risk-limit/list');
@@ -332,7 +340,9 @@ export class InverseClient extends SharedEndpoints {
     return this.requestWrapper.post('open-api/wallet/risk-limit', params);
   }
   
-  //Funding
+	/**
+   * Funding
+   */
 
   getLastFundingRate(params: {
     symbol: string;
@@ -352,7 +362,9 @@ export class InverseClient extends SharedEndpoints {
     return this.requestWrapper.get('v2/private/funding/predicted-funding', params);
   }
   
-  //misc
+	/**
+   * LCP Info
+   */
 
   getLcpInfo(params: {
     symbol: string;

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -338,9 +338,7 @@ export class InverseClient extends SharedEndpoints {
     return this.requestWrapper.get('v2/private/trade/closed-pnl/list', params);
   }
 
-  getRiskLimitList(params: {
-        symbol: string;
-    }): GenericAPIResponse {
+  getRiskLimitList(): GenericAPIResponse {
     return this.requestWrapper.get('open-api/wallet/risk-limit/list');
   }
 

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -67,33 +67,6 @@ export class InverseClient extends SharedEndpoints {
     return this.requestWrapper.get('v2/public/trading-records', params);
   }
 
-  getSymbols(): GenericAPIResponse {
-    return this.requestWrapper.get('v2/public/symbols');
-  }
-
-  /**
-   * @deprecated use getLiquidations() instead
-   */
-  getPublicLiquidations(params: {
-    symbol: string;
-    from?: number;
-    limit?: number;
-    start_time?: number;
-    end_time?: number;
-  }): GenericAPIResponse {
-    return this.getLiquidations(params);
-  }
-
-  getLiquidations(params: {
-    symbol: string;
-    from?: number;
-    limit?: number;
-    start_time?: number;
-    end_time?: number;
-  }): GenericAPIResponse {
-    return this.requestWrapper.get('v2/public/liq-records', params);
-  }
-
   getMarkPriceKline(params: {
     symbol: string;
     interval: string;

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -47,8 +47,6 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/public/kline/list', params);
   }
-rn this.requestWrapper.get('v2/public/tickers', params);
-  }
 
   /**
    * @deprecated use getTrades() instead

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -112,29 +112,6 @@ export class InverseClient extends SharedEndpoints {
     return this.requestWrapper.get('v2/public/premium-index-kline', params);
   }
 
-  getOpenInterest(params: {
-    symbol: string;
-    period: string;
-    limit?: number;
-  }): GenericAPIResponse {
-    return this.requestWrapper.get('v2/public/open-interest', params);
-  }
-
-  getLatestBigDeal(params: {
-    symbol: string;
-    limit?: number;
-  }): GenericAPIResponse {
-    return this.requestWrapper.get('v2/public/big-deal', params);
-  }
-
-  getLongShortRatio(params: {
-    symbol: string;
-    period: string;
-    limit?: number;
-  }): GenericAPIResponse {
-    return this.requestWrapper.get('v2/public/account-ratio', params);
-  }
-
   //-----------Account Data Endpoints------------>
 
   placeActiveOrder(orderRequest: {

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -33,11 +33,7 @@ export class InverseClient extends SharedEndpoints {
     return this;
   }
 
-  /**
-   *
-   * Market Data Endpoints
-   *
-   */
+  //------------Market Data Endpoints------------>
 
   getKline(params: {
     symbol: string;
@@ -117,11 +113,7 @@ export class InverseClient extends SharedEndpoints {
     return this.requestWrapper.get('v2/public/account-ratio', params);
   }
 
-  /**
-   *
-   * Account Data Endpoints
-   *
-   */
+  //-----------Account Data Endpoints------------>
 
   placeActiveOrder(orderRequest: {
     side: string;
@@ -136,9 +128,6 @@ export class InverseClient extends SharedEndpoints {
     close_on_trigger?: boolean;
     order_link_id?: string;
   }): GenericAPIResponse {
-    // if (orderRequest.order_type === 'Limit' && !orderRequest.price) {
-    //   throw new Error('Price required for limit orders');
-    // }
     return this.requestWrapper.post('v2/private/order/create', orderRequest);
   }
 
@@ -157,9 +146,6 @@ export class InverseClient extends SharedEndpoints {
     order_id?: string;
     order_link_id?: string;
   }): GenericAPIResponse {
-    // if (!params.order_id && !params.order_link_id) {
-    //   throw new Error('Parameter order_id OR order_link_id is required');
-    // }
     return this.requestWrapper.post('v2/private/order/cancel', params);
   }
 
@@ -176,9 +162,6 @@ export class InverseClient extends SharedEndpoints {
     p_r_qty?: string;
     p_r_price?: string;
   }): GenericAPIResponse {
-    // if (!params.order_id && !params.order_link_id) {
-    //   throw new Error('Parameter order_id OR order_link_id is required');
-    // }
     return this.requestWrapper.post('v2/private/order/replace', params);
   }
 
@@ -187,9 +170,6 @@ export class InverseClient extends SharedEndpoints {
     order_link_id?: string;
     symbol: string;
   }): GenericAPIResponse {
-    // if (!params.order_id && !params.order_link_id) {
-    //   throw new Error('Parameter order_id OR order_link_id is required');
-    // }
     return this.requestWrapper.get('v2/private/order', params);
   }
 
@@ -206,9 +186,6 @@ export class InverseClient extends SharedEndpoints {
     close_on_trigger?: boolean;
     order_link_id?: string;
   }): GenericAPIResponse {
-    // if (params.order_type === 'Limit' && !params.price) {
-    //   throw new Error('Parameter price is required for limit orders');
-    // }
     return this.requestWrapper.post('v2/private/stop-order/create', params);
   }
 
@@ -227,9 +204,6 @@ export class InverseClient extends SharedEndpoints {
     stop_order_id?: string;
     order_link_id?: string;
   }): GenericAPIResponse {
-    // if (!params.stop_order_id && !params.order_link_id) {
-    //   throw new Error('Parameter stop_order_id OR order_link_id is required');
-    // }
     return this.requestWrapper.post('v2/private/stop-order/cancel', params);
   }
 
@@ -247,9 +221,6 @@ export class InverseClient extends SharedEndpoints {
     p_r_price?: string;
     p_r_trigger_price?: string;
   }): GenericAPIResponse {
-    // if (!params.stop_order_id && !params.order_link_id) {
-    //   throw new Error('Parameter stop_order_id OR order_link_id is required');
-    // }
     return this.requestWrapper.post('v2/private/stop-order/replace', params);
   }
 
@@ -258,9 +229,6 @@ export class InverseClient extends SharedEndpoints {
     stop_order_id?: string;
     order_link_id?: string;
   }): GenericAPIResponse {
-    // if (!params.stop_order_id && !params.order_link_id) {
-    //   throw new Error('Parameter stop_order_id OR order_link_id is required');
-    // }
     return this.requestWrapper.get('v2/private/stop-order', params);
   }
 
@@ -372,7 +340,6 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/private/account/lcp', params);
   }
-
 
   async getTimeOffset(): Promise<number> {
     const start = Date.now();

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -3,7 +3,7 @@ import { GenericAPIResponse, getBaseRESTInverseUrl, RestClientInverseOptions } f
 import RequestWrapper from './util/requestWrapper';
 import { SharedEndpoints } from './shared-endpoints';
 
-export class InverseClient extends SharedEndpoints {
+export default class InverseClient extends SharedEndpoints {
   protected requestWrapper: RequestWrapper;
 
   /**

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -340,12 +340,4 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/private/account/lcp', params);
   }
-
-  async getTimeOffset(): Promise<number> {
-    const start = Date.now();
-    return this.getServerTime().then(result => {
-      const end = Date.now();
-      return Math.ceil((result.time_now * 1000) - end + ((end - start) / 2));
-    });
-  }
 };

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -75,6 +75,24 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/public/mark-price-kline', params);
   }
+  
+  getIndexPriceKline(params: {
+    symbol: string;
+    interval: string;
+    from: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/index-price-kline', params);
+  }
+  
+   getPremiumIndexKline(params: {
+    symbol: string;
+    interval: string;
+    from: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/premium-index-kline', params);
+  }
 
   getOpenInterest(params: {
     symbol: string;

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -81,7 +81,7 @@ export class InverseClient extends SharedEndpoints {
     return this.requestWrapper.get('v2/public/index-price-kline', params);
   }
   
-   getPremiumIndexKline(params: {
+  getPremiumIndexKline(params: {
     symbol: string;
     interval: string;
     from: number;

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -274,7 +274,7 @@ export class InverseClient extends SharedEndpoints {
     symbol: string;
     leverage: number;
   }): GenericAPIResponse {
-    return this.requestWrapper.post('user/leverage/save', params);
+    return this.requestWrapper.post('v2/private/position/leverage/save', params);
   }
 
   /**
@@ -320,7 +320,7 @@ export class InverseClient extends SharedEndpoints {
   getLastFundingRate(params: {
     symbol: string;
   }): GenericAPIResponse {
-    return this.requestWrapper.get('v2/private/funding/prev-funding-rate', params);
+    return this.requestWrapper.get('v2/public/funding/prev-funding-rate', params);
   }
 
   getMyLastFundingFee(params: {

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -338,7 +338,9 @@ export class InverseClient extends SharedEndpoints {
     return this.requestWrapper.get('v2/private/trade/closed-pnl/list', params);
   }
 
-  getRiskLimitList(): GenericAPIResponse {
+  getRiskLimitList(params: {
+        symbol: string;
+    }): GenericAPIResponse {
     return this.requestWrapper.get('open-api/wallet/risk-limit/list');
   }
 

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -71,6 +71,19 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/public/trading-records', params);
   }
+  
+  /**
+   * @deprecated use getLiquidations() instead
+   */
+  getPublicLiquidations(params: {
+    symbol: string;
+    from?: number;
+    limit?: number;
+    start_time?: number;
+    end_time?: number;
+  }): GenericAPIResponse {
+    return this.getLiquidations(params);
+  }
 
   getMarkPriceKline(params: {
     symbol: string;

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig } from 'axios';
-import { GenericAPIResponse, getBaseRESTInverseUrl, RestClientInverseOptions } from './util/requestUtils';
+import { GenericAPIResponse, getRestBaseUrl, RestClientOptions } from './util/requestUtils';
 import RequestWrapper from './util/requestWrapper';
 import SharedEndpoints from './shared-endpoints';
 
@@ -12,23 +12,23 @@ export class InverseClient extends SharedEndpoints {
    * @param {string} key - your API key
    * @param {string} secret - your API secret
    * @param {boolean} [useLivenet=false]
-   * @param {RestClientInverseOptions} [restInverseOptions={}] options to configure REST API connectivity
+   * @param {RestClientOptions} [restInverseOptions={}] options to configure REST API connectivity
    * @param {AxiosRequestConfig} [requestOptions={}] HTTP networking options for axios
    */
   constructor(
     key?: string | undefined,
     secret?: string | undefined,
     useLivenet?: boolean,
-    restInverseOptions: RestClientInverseOptions = {},
-    httpOptions: AxiosRequestConfig = {}
+    restInverseOptions: RestClientOptions = {},
+    requestOptions: AxiosRequestConfig = {}
   ) {
     super()
     this.requestWrapper = new RequestWrapper(
       key,
       secret,
-      getBaseRESTInverseUrl(useLivenet),
+      getRestBaseUrl(useLivenet),
       restInverseOptions,
-      httpOptions
+      requestOptions
     );
     return this;
   }
@@ -47,7 +47,7 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/public/kline/list', params);
   }
-  
+
   /**
    * @deprecated use getTickers() instead
    */
@@ -56,7 +56,7 @@ export class InverseClient extends SharedEndpoints {
    }): GenericAPIResponse {
     return this.getTickers(params);
    }
-  
+
   /**
    * @deprecated use getTrades() instead
    */
@@ -75,7 +75,7 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/public/trading-records', params);
   }
-  
+
   /**
    * @deprecated use getLiquidations() instead
    */
@@ -97,7 +97,7 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/public/mark-price-kline', params);
   }
-  
+
   getIndexPriceKline(params: {
     symbol: string;
     interval: string;
@@ -106,7 +106,7 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/public/index-price-kline', params);
   }
-  
+
   getPremiumIndexKline(params: {
     symbol: string;
     interval: string;
@@ -121,7 +121,7 @@ export class InverseClient extends SharedEndpoints {
    * Account Data Endpoints
    *
    */
-  
+
 	/**
    * Active orders
    */
@@ -183,7 +183,7 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/private/order', params);
   }
-  
+
 	/**
    * Conditional orders
    */
@@ -246,7 +246,7 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/private/stop-order', params);
   }
-  
+
 	/**
    * Position
    */
@@ -328,7 +328,7 @@ export class InverseClient extends SharedEndpoints {
 	/**
    * Risk Limit
    */
-  
+
   getRiskLimitList(): GenericAPIResponse {
     return this.requestWrapper.get('open-api/wallet/risk-limit/list');
   }
@@ -339,7 +339,7 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.post('open-api/wallet/risk-limit', params);
   }
-  
+
 	/**
    * Funding
    */
@@ -361,7 +361,7 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/private/funding/predicted-funding', params);
   }
-  
+
 	/**
    * LCP Info
    */

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -39,12 +39,6 @@ export class InverseClient extends SharedEndpoints {
    *
    */
 
-  getOrderBook(params: {
-    symbol: string;
-  }): GenericAPIResponse {
-    return this.requestWrapper.get('v2/public/orderBook/L2', params);
-  }
-
   getKline(params: {
     symbol: string;
     interval: string;
@@ -53,20 +47,7 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/public/kline/list', params);
   }
-
-  /**
-   * @deprecated use getTickers() instead
-   */
-  getLatestInformation(params?: {
-    symbol?: string;
-  }): GenericAPIResponse {
-    return this.getTickers(params);
-  }
-
-  getTickers(params?: {
-    symbol?: string;
-  }): GenericAPIResponse {
-    return this.requestWrapper.get('v2/public/tickers', params);
+rn this.requestWrapper.get('v2/public/tickers', params);
   }
 
   /**

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -43,7 +43,16 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/public/kline/list', params);
   }
-
+  
+  /**
+   * @deprecated use getTickers() instead
+   */
+  getLatestInformation(params?: {
+    symbol?: string;
+   }): GenericAPIResponse {
+    return this.getTickers(params);
+   }
+  
   /**
    * @deprecated use getTrades() instead
    */

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -367,10 +367,6 @@ export class InverseClient extends SharedEndpoints {
     return this.requestWrapper.get('v2/private/funding/predicted-funding', params);
   }
 
-  getApiKeyInfo(): GenericAPIResponse {
-    return this.requestWrapper.get('v2/private/account/api-key');
-  }
-
   getLcpInfo(params: {
     symbol: string;
   }): GenericAPIResponse {

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -152,21 +152,6 @@ export class InverseClient extends SharedEndpoints {
     return this.requestWrapper.get('v2/private/order/list', params);
   }
 
-  /**
-   * @deprecated use getActiveOrderList() instead
-   */
-  getActiveOrder(params: {
-    order_id?: string;
-    order_link_id?: string;
-    symbol?: string;
-    order?: string;
-    page?: number;
-    limit?: number;
-    order_status?: string;
-  }): GenericAPIResponse {
-    return this.requestWrapper.get('open-api/order/list', params);
-  }
-
   cancelActiveOrder(params: {
     symbol: string;
     order_id?: string;
@@ -195,16 +180,6 @@ export class InverseClient extends SharedEndpoints {
     //   throw new Error('Parameter order_id OR order_link_id is required');
     // }
     return this.requestWrapper.post('v2/private/order/replace', params);
-  }
-
-  /**
-   * @deprecated use replaceActiveOrder()
-   */
-  replaceActiveOrderOld(params: any): GenericAPIResponse {
-    // if (!params.order_id && !params.order_link_id) {
-    //   throw new Error('Parameter order_id OR order_link_id is required');
-    // }
-    return this.requestWrapper.post('open-api/order/replace', params);
   }
 
   queryActiveOrder(params: {
@@ -237,16 +212,6 @@ export class InverseClient extends SharedEndpoints {
     return this.requestWrapper.post('v2/private/stop-order/create', params);
   }
 
-  /**
-   * @deprecated use placeConditionalOrder
-   */
-  placeConditionalOrderOld(params: any): GenericAPIResponse {
-    // if (params.order_type === 'Limit' && !params.price) {
-    //   throw new Error('Parameter price is required for limit orders');
-    // }
-    return this.requestWrapper.post('open-api/stop-order/create', params);
-  }
-
   getConditionalOrder(params: {
     symbol: string;
     stop_order_status?: string;
@@ -255,13 +220,6 @@ export class InverseClient extends SharedEndpoints {
     cursor?: string;
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/private/stop-order/list', params);
-  }
-
-  /**
-   * @deprecated use placeConditionalOrder
-   */
-  getConditionalOrderOld(params: any): GenericAPIResponse {
-    return this.requestWrapper.get('open-api/stop-order/list', params);
   }
 
   cancelConditionalOrder(params: {
@@ -273,16 +231,6 @@ export class InverseClient extends SharedEndpoints {
     //   throw new Error('Parameter stop_order_id OR order_link_id is required');
     // }
     return this.requestWrapper.post('v2/private/stop-order/cancel', params);
-  }
-
-  /**
-   * @deprecated use cancelConditionalOrder
-   */
-  cancelConditionalOrderOld(params: any): GenericAPIResponse {
-    // if (!params.stop_order_id && !params.order_link_id) {
-    //   throw new Error('Parameter stop_order_id OR order_link_id is required');
-    // }
-    return this.requestWrapper.post('open-api/stop-order/cancel', params);
   }
 
   cancelAllConditionalOrders(params: {
@@ -303,13 +251,6 @@ export class InverseClient extends SharedEndpoints {
     //   throw new Error('Parameter stop_order_id OR order_link_id is required');
     // }
     return this.requestWrapper.post('v2/private/stop-order/replace', params);
-  }
-
-  /**
-   * @deprecated use replaceConditionalOrder
-   */
-  replaceConditionalOrderOld(params: any): GenericAPIResponse {
-    return this.requestWrapper.post('open-api/stop-order/replace', params);
   }
 
   queryConditionalOrder(params: {
@@ -358,7 +299,7 @@ export class InverseClient extends SharedEndpoints {
     sl_trigger_by?: string;
     new_trailing_active?: number;
   }): GenericAPIResponse {
-    return this.requestWrapper.post('open-api/position/trading-stop', params);
+    return this.requestWrapper.post('v2/private/position/trading-stop', params);
   }
 
   setUserLeverage(params: {
@@ -411,23 +352,23 @@ export class InverseClient extends SharedEndpoints {
   getLastFundingRate(params: {
     symbol: string;
   }): GenericAPIResponse {
-    return this.requestWrapper.get('open-api/funding/prev-funding-rate', params);
+    return this.requestWrapper.get('v2/private/funding/prev-funding-rate', params);
   }
 
   getMyLastFundingFee(params: {
     symbol: string;
   }): GenericAPIResponse {
-    return this.requestWrapper.get('open-api/funding/prev-funding', params);
+    return this.requestWrapper.get('v2/private/funding/prev-funding', params);
   }
 
   getPredictedFunding(params: {
     symbol: string;
   }): GenericAPIResponse {
-    return this.requestWrapper.get('open-api/funding/predicted-funding', params);
+    return this.requestWrapper.get('v2/private/funding/predicted-funding', params);
   }
 
   getApiKeyInfo(): GenericAPIResponse {
-    return this.requestWrapper.get('open-api/api-key');
+    return this.requestWrapper.get('v2/private/account/api-key');
   }
 
   getLcpInfo(params: {

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -1,9 +1,9 @@
 import { AxiosRequestConfig } from 'axios';
 import { GenericAPIResponse, getBaseRESTInverseUrl, RestClientInverseOptions } from './util/requestUtils';
 import RequestWrapper from './util/requestWrapper';
-import { SharedEndpoints } from './shared-endpoints';
+import SharedEndpoints from './shared-endpoints';
 
-export default class InverseClient extends SharedEndpoints {
+export class InverseClient extends SharedEndpoints {
   protected requestWrapper: RequestWrapper;
 
   /**

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -1,9 +1,10 @@
 import { AxiosRequestConfig } from 'axios';
 import { GenericAPIResponse, getBaseRESTInverseUrl, RestClientInverseOptions } from './util/requestUtils';
 import RequestWrapper from './util/requestWrapper';
+import { SharedEndpoints } from './shared-endpoints';
 
-export class RestClient {
-  private requestWrapper: RequestWrapper;
+export class InverseClient extends SharedEndpoints {
+  protected requestWrapper: RequestWrapper;
 
   /**
    * @public Creates an instance of the inverse REST API client.
@@ -21,6 +22,7 @@ export class RestClient {
     restInverseOptions: RestClientInverseOptions = {},
     httpOptions: AxiosRequestConfig = {}
   ) {
+    super()
     this.requestWrapper = new RequestWrapper(
       key,
       secret,
@@ -464,62 +466,6 @@ export class RestClient {
     return this.requestWrapper.get('v2/private/account/lcp', params);
   }
 
-  /**
-   *
-   * Wallet Data Endpoints
-   *
-   */
-
-  getWalletBalance(params?: {
-    coin?: string;
-  }): GenericAPIResponse {
-    return this.requestWrapper.get('v2/private/wallet/balance', params);
-  }
-
-  getWalletFundRecords(params?: {
-    start_date?: string;
-    end_date?: string;
-    currency?: string;
-    coin?: string;
-    wallet_fund_type?: string;
-    page?: number;
-    limit?: number;
-  }): GenericAPIResponse {
-    return this.requestWrapper.get('open-api/wallet/fund/records', params);
-  }
-
-  getWithdrawRecords(params: {
-    start_date?: string;
-    end_date?: string;
-    coin?: string;
-    status?: string;
-    page?: number;
-    limit?: number;
-  }): GenericAPIResponse {
-    return this.requestWrapper.get('open-api/wallet/withdraw/list', params);
-  }
-
-  getAssetExchangeRecords(params?: {
-    limit?: number;
-    from?: number;
-    direction?: string;
-  }): GenericAPIResponse {
-    return this.requestWrapper.get('v2/private/exchange-order/list', params);
-  }
-
-  /**
-   *
-   * API Data Endpoints
-   *
-   */
-
-  getServerTime(): GenericAPIResponse {
-    return this.requestWrapper.get('v2/public/time');
-  }
-
-  getApiAnnouncements(): GenericAPIResponse {
-    return this.requestWrapper.get('v2/public/announcement');
-  }
 
   async getTimeOffset(): Promise<number> {
     const start = Date.now();

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -33,7 +33,11 @@ export class InverseClient extends SharedEndpoints {
     return this;
   }
 
-  //------------Market Data Endpoints------------>
+  /**
+   *
+   * Market Data Endpoints
+   *
+   */
 
   getKline(params: {
     symbol: string;
@@ -112,7 +116,13 @@ export class InverseClient extends SharedEndpoints {
     return this.requestWrapper.get('v2/public/premium-index-kline', params);
   }
 
-  //-----------Account Data Endpoints------------>
+  /**
+   *
+   * Account Data Endpoints
+   *
+   */
+  
+  //Active Orders
 
   placeActiveOrder(orderRequest: {
     side: string;
@@ -171,6 +181,8 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/private/order', params);
   }
+  
+  //Conditional Orders
 
   placeConditionalOrder(params: {
     side: string;
@@ -230,6 +242,8 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/private/stop-order', params);
   }
+  
+  //Position
 
   /**
    * @deprecated use getPosition() instead
@@ -305,6 +319,8 @@ export class InverseClient extends SharedEndpoints {
     return this.requestWrapper.get('v2/private/trade/closed-pnl/list', params);
   }
 
+  //Risk Limit
+  
   getRiskLimitList(): GenericAPIResponse {
     return this.requestWrapper.get('open-api/wallet/risk-limit/list');
   }
@@ -315,6 +331,8 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.post('open-api/wallet/risk-limit', params);
   }
+  
+  //Funding
 
   getLastFundingRate(params: {
     symbol: string;
@@ -333,6 +351,8 @@ export class InverseClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/private/funding/predicted-funding', params);
   }
+  
+  //misc
 
   getLcpInfo(params: {
     symbol: string;

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -160,9 +160,9 @@ export class LinearClient extends SharedEndpoints {
     return this.requestWrapper.get('private/linear/order/search', params);
   }
 
-	/**
-   * Conditional orders
-   */
+  /**
+  * Conditional orders
+  */
 
   placeConditionalOrder(params: {
     side: string;

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -3,7 +3,7 @@ import { GenericAPIResponse, getBaseRESTInverseUrl, RestClientInverseOptions } f
 import RequestWrapper from './util/requestWrapper';
 import SharedEndpoints from './shared-endpoints';
 
-export default class LinearClient extends SharedEndpoints {
+export class LinearClient extends SharedEndpoints {
     protected requestWrapper: RequestWrapper;
 
     /**

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -97,7 +97,7 @@ export class LinearClient extends SharedEndpoints {
 		return this.requestWrapper.get('public/linear/premium-index-kline', params);
 	}
 	
-	//-----------Account Data Endpoints------------>
+	//------------Account Data Endpoints------------>
 	
 	//Active Orders
 	

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -338,9 +338,9 @@ export class LinearClient extends SharedEndpoints {
     return this.requestWrapper.get('private/linear/position/set-risk', params);
   }
 
-	/**
-   * Funding
-   */
+  /**
+  * Funding
+  */
 
   getPredictedFundingFee(params: {
     symbol: string;

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -307,8 +307,8 @@ export class LinearClient extends SharedEndpoints {
         start_time?: number;
         end_time?: number;
         exec_type?: string;
-        page?: integer;
-        limit?: intiger;
+        page?: number;
+        limit?: number;
     }): GenericAPIResponse {
         return this.requestWrapper.get('private/linear/trade/execution/list', params);
     }

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -4,9 +4,9 @@ import RequestWrapper from './util/requestWrapper';
 import SharedEndpoints from './shared-endpoints';
 
 export class LinearClient extends SharedEndpoints {
-    protected requestWrapper: RequestWrapper;
+	protected requestWrapper: RequestWrapper;
 
-    /**
+	/**
    * @public Creates an instance of the inverse REST API client.
    *
    * @param {string} key - your API key
@@ -16,334 +16,334 @@ export class LinearClient extends SharedEndpoints {
    * @param {AxiosRequestConfig} [requestOptions={}] HTTP networking options for axios
    */
 
-    constructor(
-        key?: string | undefined,
-        secret?: string | undefined,
-        livenet?: boolean,
-        restInverseOptions:RestClientInverseOptions = {}, // TODO: Rename this type to be more general.
-        requestOptions: AxiosRequestConfig = {}
-      ) {
-        super()
-        this.requestWrapper = new RequestWrapper(
-            key,
-            secret,
-            getBaseRESTInverseUrl(livenet),
-            restInverseOptions,
-            requestOptions
-        );
-        return this;
-      }
-    
-    //------------Market Data Endpoints------------>
-    
-    getKline(params: {
-        symbol: string;
-        interval: string;
-        from: number;
-        limit?: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('/public/linear/kline', params);
-    }
+	constructor(
+		key?: string | undefined,
+		secret?: string | undefined,
+		livenet?: boolean,
+		restInverseOptions:RestClientInverseOptions = {}, // TODO: Rename this type to be more general.
+		requestOptions: AxiosRequestConfig = {}
+	  ) {
+		super()
+		this.requestWrapper = new RequestWrapper(
+			key,
+			secret,
+			getBaseRESTInverseUrl(livenet),
+			restInverseOptions,
+			requestOptions
+		);
+		return this;
+	  }
+	
+	//------------Market Data Endpoints------------>
+	
+	getKline(params: {
+		symbol: string;
+		interval: string;
+		from: number;
+		limit?: number;
+	}): GenericAPIResponse {
+		return this.requestWrapper.get('/public/linear/kline', params);
+	}
    
-    /**
-    * @deprecated use getTrades() instead
-    */
-    getPublicTradingRecords(params: {
-        symbol: string;
-        from?: number;
-        limit?: number;
-    }): GenericAPIResponse {
-        return this.getTrades(params);
-    }
+	/**
+	* @deprecated use getTrades() instead
+	*/
+	getPublicTradingRecords(params: {
+		symbol: string;
+		from?: number;
+		limit?: number;
+	}): GenericAPIResponse {
+		return this.getTrades(params);
+	}
 
-    getTrades(params: {
-        symbol: string;
-        //from?: number;
-        limit?: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('public/linear/recent-trading-records', params);
-    }
-    
-    getLastFundingRate(params: {
-      symbol: string;
-    }): GenericAPIResponse {
-      return this.requestWrapper.get('public/linear/funding/prev-funding-rate', params);
-    }
-    
-    getMarkPriceKline(params: {
-        symbol: string;
-        interval: string;
-        from: number;
-        limit?: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('public/linear/mark-price-kline', params);
-    }
-    
-    getIndexPriceKline(params: {
-        symbol: string;
-        interval: string;
-        from: number;
-        limit?: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('public/linear/index-price-kline', params);
-    }
-    
-    getPremiumIndexKline(params: {
-        symbol: string;
-        interval: string;
-        from: number;
-        limit?: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('public/linear/premium-index-kline', params);
-    }
-    
-    //-----------Account Data Endpoints------------>
-    
-    //Active Orders
-    
-    placeActiveOrder(orderRequest: {
-        side: string;
-        symbol: string;
-        order_type: string;
-        qty: number;
-        price?: number;
-        time_in_force: string;
-        take_profit?: number;
-        stop_loss?: number;
-        tp_trigger_by?: string;
-        sl_trigger_by?: string;
-        reduce_only?: boolean;
-        close_on_trigger?: boolean;
-        order_link_id?: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.post('private/linear/order/create', orderRequest);
-     }
-    
-     getActiveOrderList(params: {
-        order_id?: string;
-        order_link_id?: string;
-        symbol: string;
-        order?: string;
-        page?: number;
-        limit?: number;
-        order_status?: string;
-        
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('private/linear/order/list', params);
-    }
-    
-    cancelActiveOrder(params: {
-        symbol: string;
-        order_id?: string;
-        order_link_id?: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.post('private/linear/order/cancel', params);
-    }
-    
-    cancelAllActiveOrders(params: {
-        symbol: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.post('private/linear/order/cancel-all', params);
-    }
-    
-    replaceActiveOrder(params: {
-        order_id?: string;
-        order_link_id?: string;
-        symbol: string;
-        p_r_qty?: number;
-        p_r_price?: number;
-        take_profit?: number;
-        stop_loss?: number;
-        tp_trigger_by?: string;
-        sl_trigger_by?: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.post('private/linear/order/replace', params);
-    }
-    
-    queryActiveOrder(params: {
-        order_id?: string;
-        order_link_id?: string;
-        symbol: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('private/linear/order/search', params);
-    }
-    
-    //Conditional Orders
-    
-    placeConditionalOrder(params: {
-        side: string;
-        symbol: string;
-        order_type: string;
-        qty: number;
-        price?: number;
-        base_price: number;
-        stop_px: number;
-        time_in_force: string;
-        trigger_by?: string;
-        close_on_trigger?: boolean;
-        order_link_id?: string;
-        reduce_only: boolean;
-        take_profit?: number;
-        stop_loss?: number;
-        tp_trigger_by?: string;
-        sl_trigger_by?: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.post('private/linear/stop-order/create', params);
-    }
-    
-    getConditionalOrder(params: {
-        stop_order_id?: string;
-        order_link_id?: string;
-        symbol: string;
-        stop_order_status?: string;
-        order?: string;
-        page?: number;
-        limit?: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('private/linear/stop-order/list', params);
-    }
-    
-    cancelConditionalOrder(params: {
-        symbol: string;
-        stop_order_id?: string;
-        order_link_id?: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.post('private/linear/stop-order/cancel', params);
-    }
-    
-    cancelAllConditionalOrders(params: {
-        symbol: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.post('private/linear/stop-order/cancel-all', params);
-    }
-    
-    replaceConditionalOrder(params: {
-        stop_order_id?: string;
-        order_link_id?: string;
-        symbol: string;
-        p_r_qty?: number;
-        p_r_price?: number;
-        p_r_trigger_price?: number;
-        take_profit?: number;
-        stop_loss?: number;
-        tp_trigger_by?: string;
-        sl_trigger_by?: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.post('private/linear/stop-order/replace', params);
-    }
-    
-    queryConditionalOrder(params: {
-        symbol: string;
-        stop_order_id?: string;
-        order_link_id?: string;
-    }): GenericAPIResponse {
-    return this.requestWrapper.get('private/linear/stop-order/search', params);
-    }
-    
-    //Position
-    
-    getPosition(params?: {
-        symbol?: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('private/linear/position/list', params);
-    }
-    
-    setAutoAddMargin(params?: {
-        symbol: string;
-        side: string;
-        auto_add_margin: boolean;
-    }): GenericAPIResponse {
-        return this.requestWrapper.post('private/linear/position/set-auto-add-margin', params);
-    }
-    
-    setMarginSwitch(params?: {
-        symbol: string;
-        is_isolated: boolean;
-        buy_leverage: number;
-        sell_leverage: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.post('private/linear/position/switch-isolated', params);
-    }
-    
-    setSwitchMode(params?: {
-        symbol: string;
-        tp_sl_mode: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.post('private/linear/tpsl/switch-mode', params);
-    }
-    
-    setAddReduceMargin(params?: {
-        symbol: string;
-        side: string;
-        margin: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.post('private/linear/position/add-margin', params);
-    }
-    
-    setUserLeverage(params: {
-        symbol: string;
-        buy_leverage: number;
-        sell_leverage: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.post('private/linear/position/set-leverage', params);
-    }
-    
-    setTradingStop(params: {
-        symbol: string;
-        side: string;
-        take_profit?: number;
-        stop_loss?: number;
-        trailing_stop?: number;
-        tp_trigger_by?: string;
-        sl_trigger_by?: string;
-        sl_size?: number;
-        tp_size?: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.post('private/linear/position/trading-stop', params);
-    }
-    
-    getTradeRecords(params: {
-        symbol: string;
-        start_time?: number;
-        end_time?: number;
-        exec_type?: string;
-        page?: number;
-        limit?: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('private/linear/trade/execution/list', params);
-    }
-    
-    getClosedPnl(params: {
-        symbol: string;
-        start_time?: number;
-        end_time?: number;
-        exec_type?: string;
-        page?: number;
-        limit?: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('private/linear/tpsl/switch-mode', params);
-    }
-    
-    //Risk Limit
-    
-    getRiskLimitList(params: {
-        symbol: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('public/linear/risk-limit');
-    }
-    
-    //Funding
-    
-    getPredictedFundingFee(params: {
-        symbol: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('private/linear/funding/predicted-funding');
-    }
-    
-    getLastFundingFee(params: {
-        symbol: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('private/linear/funding/prev-funding');
-    }
-    
+	getTrades(params: {
+		symbol: string;
+		//from?: number;
+		limit?: number;
+	}): GenericAPIResponse {
+		return this.requestWrapper.get('public/linear/recent-trading-records', params);
+	}
+	
+	getLastFundingRate(params: {
+	  symbol: string;
+	}): GenericAPIResponse {
+	  return this.requestWrapper.get('public/linear/funding/prev-funding-rate', params);
+	}
+	
+	getMarkPriceKline(params: {
+		symbol: string;
+		interval: string;
+		from: number;
+		limit?: number;
+	}): GenericAPIResponse {
+		return this.requestWrapper.get('public/linear/mark-price-kline', params);
+	}
+	
+	getIndexPriceKline(params: {
+		symbol: string;
+		interval: string;
+		from: number;
+		limit?: number;
+	}): GenericAPIResponse {
+		return this.requestWrapper.get('public/linear/index-price-kline', params);
+	}
+	
+	getPremiumIndexKline(params: {
+		symbol: string;
+		interval: string;
+		from: number;
+		limit?: number;
+	}): GenericAPIResponse {
+		return this.requestWrapper.get('public/linear/premium-index-kline', params);
+	}
+	
+	//-----------Account Data Endpoints------------>
+	
+	//Active Orders
+	
+	placeActiveOrder(orderRequest: {
+		side: string;
+		symbol: string;
+		order_type: string;
+		qty: number;
+		price?: number;
+		time_in_force: string;
+		take_profit?: number;
+		stop_loss?: number;
+		tp_trigger_by?: string;
+		sl_trigger_by?: string;
+		reduce_only?: boolean;
+		close_on_trigger?: boolean;
+		order_link_id?: string;
+	}): GenericAPIResponse {
+		return this.requestWrapper.post('private/linear/order/create', orderRequest);
+	 }
+	
+	 getActiveOrderList(params: {
+		order_id?: string;
+		order_link_id?: string;
+		symbol: string;
+		order?: string;
+		page?: number;
+		limit?: number;
+		order_status?: string;
+		
+	}): GenericAPIResponse {
+		return this.requestWrapper.get('private/linear/order/list', params);
+	}
+	
+	cancelActiveOrder(params: {
+		symbol: string;
+		order_id?: string;
+		order_link_id?: string;
+	}): GenericAPIResponse {
+		return this.requestWrapper.post('private/linear/order/cancel', params);
+	}
+	
+	cancelAllActiveOrders(params: {
+		symbol: string;
+	}): GenericAPIResponse {
+		return this.requestWrapper.post('private/linear/order/cancel-all', params);
+	}
+	
+	replaceActiveOrder(params: {
+		order_id?: string;
+		order_link_id?: string;
+		symbol: string;
+		p_r_qty?: number;
+		p_r_price?: number;
+		take_profit?: number;
+		stop_loss?: number;
+		tp_trigger_by?: string;
+		sl_trigger_by?: string;
+	}): GenericAPIResponse {
+		return this.requestWrapper.post('private/linear/order/replace', params);
+	}
+	
+	queryActiveOrder(params: {
+		order_id?: string;
+		order_link_id?: string;
+		symbol: string;
+	}): GenericAPIResponse {
+		return this.requestWrapper.get('private/linear/order/search', params);
+	}
+	
+	//Conditional Orders
+	
+	placeConditionalOrder(params: {
+		side: string;
+		symbol: string;
+		order_type: string;
+		qty: number;
+		price?: number;
+		base_price: number;
+		stop_px: number;
+		time_in_force: string;
+		trigger_by?: string;
+		close_on_trigger?: boolean;
+		order_link_id?: string;
+		reduce_only: boolean;
+		take_profit?: number;
+		stop_loss?: number;
+		tp_trigger_by?: string;
+		sl_trigger_by?: string;
+	}): GenericAPIResponse {
+		return this.requestWrapper.post('private/linear/stop-order/create', params);
+	}
+	
+	getConditionalOrder(params: {
+		stop_order_id?: string;
+		order_link_id?: string;
+		symbol: string;
+		stop_order_status?: string;
+		order?: string;
+		page?: number;
+		limit?: number;
+	}): GenericAPIResponse {
+		return this.requestWrapper.get('private/linear/stop-order/list', params);
+	}
+	
+	cancelConditionalOrder(params: {
+		symbol: string;
+		stop_order_id?: string;
+		order_link_id?: string;
+	}): GenericAPIResponse {
+		return this.requestWrapper.post('private/linear/stop-order/cancel', params);
+	}
+	
+	cancelAllConditionalOrders(params: {
+		symbol: string;
+	}): GenericAPIResponse {
+		return this.requestWrapper.post('private/linear/stop-order/cancel-all', params);
+	}
+		
+	replaceConditionalOrder(params: {
+		stop_order_id?: string;
+		order_link_id?: string;
+		symbol: string;
+		p_r_qty?: number;
+		p_r_price?: number;
+		p_r_trigger_price?: number;
+		take_profit?: number;
+		stop_loss?: number;
+		tp_trigger_by?: string;
+		sl_trigger_by?: string;
+	}): GenericAPIResponse {
+		return this.requestWrapper.post('private/linear/stop-order/replace', params);
+	}
+	
+	queryConditionalOrder(params: {
+		symbol: string;
+		stop_order_id?: string;
+		order_link_id?: string;
+	}): GenericAPIResponse {
+	return this.requestWrapper.get('private/linear/stop-order/search', params);
+	}
+	
+	//Position
+	
+	getPosition(params?: {
+		symbol?: string;
+	}): GenericAPIResponse {
+		return this.requestWrapper.get('private/linear/position/list', params);
+	}
+	
+	setAutoAddMargin(params?: {
+		symbol: string;
+		side: string;
+		auto_add_margin: boolean;
+	}): GenericAPIResponse {
+		return this.requestWrapper.post('private/linear/position/set-auto-add-margin', params);
+	}
+	
+	setMarginSwitch(params?: {
+		symbol: string;
+		is_isolated: boolean;
+		buy_leverage: number;
+		sell_leverage: number;
+	}): GenericAPIResponse {
+		return this.requestWrapper.post('private/linear/position/switch-isolated', params);
+	}
+	
+	setSwitchMode(params?: {
+		symbol: string;
+		tp_sl_mode: string;
+	}): GenericAPIResponse {
+		return this.requestWrapper.post('private/linear/tpsl/switch-mode', params);
+	}
+	
+	setAddReduceMargin(params?: {
+		symbol: string;
+		side: string;
+		margin: number;
+	}): GenericAPIResponse {
+		return this.requestWrapper.post('private/linear/position/add-margin', params);
+	}
+	
+	setUserLeverage(params: {
+		symbol: string;
+		buy_leverage: number;
+		sell_leverage: number;
+	}): GenericAPIResponse {
+		return this.requestWrapper.post('private/linear/position/set-leverage', params);
+	}
+	
+	setTradingStop(params: {
+		symbol: string;
+		side: string;
+		take_profit?: number;
+		stop_loss?: number;
+		trailing_stop?: number;
+		tp_trigger_by?: string;
+		sl_trigger_by?: string;
+		sl_size?: number;
+		tp_size?: number;
+	}): GenericAPIResponse {
+		return this.requestWrapper.post('private/linear/position/trading-stop', params);
+	}
+	
+	getTradeRecords(params: {
+		symbol: string;
+		start_time?: number;
+		end_time?: number;
+		exec_type?: string;
+		page?: number;
+		limit?: number;
+	}): GenericAPIResponse {
+		return this.requestWrapper.get('private/linear/trade/execution/list', params);
+	}
+	
+	getClosedPnl(params: {
+		symbol: string;
+		start_time?: number;
+		end_time?: number;
+		exec_type?: string;
+		page?: number;
+		limit?: number;
+	}): GenericAPIResponse {
+		return this.requestWrapper.get('private/linear/tpsl/switch-mode', params);
+	}
+	
+	//Risk Limit
+	
+	getRiskLimitList(params: {
+		symbol: string;
+	}): GenericAPIResponse {
+		return this.requestWrapper.get('public/linear/risk-limit');
+	}
+	
+	//Funding
+	
+	getPredictedFundingFee(params: {
+		symbol: string;
+	}): GenericAPIResponse {
+		return this.requestWrapper.get('private/linear/funding/predicted-funding');
+	}
+	
+	getLastFundingFee(params: {
+		symbol: string;
+	}): GenericAPIResponse {
+		return this.requestWrapper.get('private/linear/funding/prev-funding');
+	}
+	
 }

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -22,7 +22,7 @@ export class LinearClient extends SharedEndpoints {
 		livenet?: boolean,
 		restInverseOptions:RestClientInverseOptions = {}, // TODO: Rename this type to be more general.
 		requestOptions: AxiosRequestConfig = {}
-	  ) {
+	) {
 		super()
 		this.requestWrapper = new RequestWrapper(
 			key,
@@ -32,10 +32,10 @@ export class LinearClient extends SharedEndpoints {
 			requestOptions
 		);
 		return this;
-	  }
-	
+	}
+
 	//------------Market Data Endpoints------------>
-	
+
 	getKline(params: {
 		symbol: string;
 		interval: string;
@@ -44,7 +44,7 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.get('/public/linear/kline', params);
 	}
-   
+
 	/**
 	* @deprecated use getTrades() instead
 	*/
@@ -63,13 +63,13 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.get('public/linear/recent-trading-records', params);
 	}
-	
+
 	getLastFundingRate(params: {
 	  symbol: string;
 	}): GenericAPIResponse {
 	  return this.requestWrapper.get('public/linear/funding/prev-funding-rate', params);
 	}
-	
+
 	getMarkPriceKline(params: {
 		symbol: string;
 		interval: string;
@@ -78,7 +78,7 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.get('public/linear/mark-price-kline', params);
 	}
-	
+
 	getIndexPriceKline(params: {
 		symbol: string;
 		interval: string;
@@ -87,7 +87,7 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.get('public/linear/index-price-kline', params);
 	}
-	
+
 	getPremiumIndexKline(params: {
 		symbol: string;
 		interval: string;
@@ -96,12 +96,12 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.get('public/linear/premium-index-kline', params);
 	}
-	
+
 	//------------Account Data Endpoints------------>
-	
+
 	//Active Orders
-	
-	placeActiveOrder(orderRequest: {
+
+	placeActiveOrder(params: {
 		side: string;
 		symbol: string;
 		order_type: string;
@@ -116,9 +116,9 @@ export class LinearClient extends SharedEndpoints {
 		close_on_trigger?: boolean;
 		order_link_id?: string;
 	}): GenericAPIResponse {
-		return this.requestWrapper.post('private/linear/order/create', orderRequest);
+		return this.requestWrapper.post('private/linear/order/create', params);
 	 }
-	
+
 	 getActiveOrderList(params: {
 		order_id?: string;
 		order_link_id?: string;
@@ -127,11 +127,11 @@ export class LinearClient extends SharedEndpoints {
 		page?: number;
 		limit?: number;
 		order_status?: string;
-		
+
 	}): GenericAPIResponse {
 		return this.requestWrapper.get('private/linear/order/list', params);
 	}
-	
+
 	cancelActiveOrder(params: {
 		symbol: string;
 		order_id?: string;
@@ -139,13 +139,13 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.post('private/linear/order/cancel', params);
 	}
-	
+
 	cancelAllActiveOrders(params: {
 		symbol: string;
 	}): GenericAPIResponse {
 		return this.requestWrapper.post('private/linear/order/cancel-all', params);
 	}
-	
+
 	replaceActiveOrder(params: {
 		order_id?: string;
 		order_link_id?: string;
@@ -159,7 +159,7 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.post('private/linear/order/replace', params);
 	}
-	
+
 	queryActiveOrder(params: {
 		order_id?: string;
 		order_link_id?: string;
@@ -167,9 +167,9 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.get('private/linear/order/search', params);
 	}
-	
+
 	//Conditional Orders
-	
+
 	placeConditionalOrder(params: {
 		side: string;
 		symbol: string;
@@ -190,7 +190,7 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.post('private/linear/stop-order/create', params);
 	}
-	
+
 	getConditionalOrder(params: {
 		stop_order_id?: string;
 		order_link_id?: string;
@@ -202,7 +202,7 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.get('private/linear/stop-order/list', params);
 	}
-	
+
 	cancelConditionalOrder(params: {
 		symbol: string;
 		stop_order_id?: string;
@@ -210,13 +210,13 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.post('private/linear/stop-order/cancel', params);
 	}
-	
+
 	cancelAllConditionalOrders(params: {
 		symbol: string;
 	}): GenericAPIResponse {
 		return this.requestWrapper.post('private/linear/stop-order/cancel-all', params);
 	}
-		
+
 	replaceConditionalOrder(params: {
 		stop_order_id?: string;
 		order_link_id?: string;
@@ -231,23 +231,23 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.post('private/linear/stop-order/replace', params);
 	}
-	
+
 	queryConditionalOrder(params: {
 		symbol: string;
 		stop_order_id?: string;
 		order_link_id?: string;
 	}): GenericAPIResponse {
-	return this.requestWrapper.get('private/linear/stop-order/search', params);
+		return this.requestWrapper.get('private/linear/stop-order/search', params);
 	}
-	
+
 	//Position
-	
+
 	getPosition(params?: {
 		symbol?: string;
 	}): GenericAPIResponse {
 		return this.requestWrapper.get('private/linear/position/list', params);
 	}
-	
+
 	setAutoAddMargin(params?: {
 		symbol: string;
 		side: string;
@@ -255,7 +255,7 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.post('private/linear/position/set-auto-add-margin', params);
 	}
-	
+
 	setMarginSwitch(params?: {
 		symbol: string;
 		is_isolated: boolean;
@@ -264,14 +264,14 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.post('private/linear/position/switch-isolated', params);
 	}
-	
+
 	setSwitchMode(params?: {
 		symbol: string;
 		tp_sl_mode: string;
 	}): GenericAPIResponse {
 		return this.requestWrapper.post('private/linear/tpsl/switch-mode', params);
 	}
-	
+
 	setAddReduceMargin(params?: {
 		symbol: string;
 		side: string;
@@ -279,7 +279,7 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.post('private/linear/position/add-margin', params);
 	}
-	
+
 	setUserLeverage(params: {
 		symbol: string;
 		buy_leverage: number;
@@ -287,7 +287,7 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.post('private/linear/position/set-leverage', params);
 	}
-	
+
 	setTradingStop(params: {
 		symbol: string;
 		side: string;
@@ -301,7 +301,7 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.post('private/linear/position/trading-stop', params);
 	}
-	
+
 	getTradeRecords(params: {
 		symbol: string;
 		start_time?: number;
@@ -312,7 +312,7 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.get('private/linear/trade/execution/list', params);
 	}
-	
+
 	getClosedPnl(params: {
 		symbol: string;
 		start_time?: number;
@@ -323,27 +323,27 @@ export class LinearClient extends SharedEndpoints {
 	}): GenericAPIResponse {
 		return this.requestWrapper.get('private/linear/tpsl/switch-mode', params);
 	}
-	
+
 	//Risk Limit
-	
+
 	getRiskLimitList(params: {
 		symbol: string;
 	}): GenericAPIResponse {
 		return this.requestWrapper.get('public/linear/risk-limit');
 	}
-	
+
 	//Funding
-	
+
 	getPredictedFundingFee(params: {
 		symbol: string;
 	}): GenericAPIResponse {
 		return this.requestWrapper.get('private/linear/funding/predicted-funding');
 	}
-	
+
 	getLastFundingFee(params: {
 		symbol: string;
 	}): GenericAPIResponse {
 		return this.requestWrapper.get('private/linear/funding/prev-funding');
 	}
-	
+
 }

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -241,6 +241,89 @@ export class LinearClient extends SharedEndpoints {
     }
     
     //Position
+    
+    getPosition(params?: {
+        symbol?: string;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('private/linear/position/list', params);
+    }
+    
+    setAutoAddMargin(params?: {
+        symbol: string;
+        side: string;
+        auto_add_margin: boolean;
+    }): GenericAPIResponse {
+        return this.requestWrapper.post('private/linear/position/set-auto-add-margin', params);
+    }
+    
+    setMarginSwitch(params?: {
+        symbol: string;
+        is_isolated: boolean;
+        buy_leverage: number;
+        sell_leverage: number;
+    }): GenericAPIResponse {
+        return this.requestWrapper.post('private/linear/position/switch-isolated', params);
+    }
+    
+    setSwitchMode(params?: {
+        symbol: string;
+        tp_sl_mode: string;
+    }): GenericAPIResponse {
+        return this.requestWrapper.post('private/linear/tpsl/switch-mode', params);
+    }
+    
+    setAddReduceMargin(params?: {
+        symbol: string;
+        side: string;
+        margin: number;
+    }): GenericAPIResponse {
+        return this.requestWrapper.post('private/linear/position/add-margin', params);
+    }
+    
+    setUserLeverage(params: {
+        symbol: string;
+        buy_leverage: number;
+        sell_leverage: number;
+    }): GenericAPIResponse {
+        return this.requestWrapper.post('private/linear/position/set-leverage', params);
+    }
+    
+    setTradingStop(params: {
+        symbol: string;
+        side: string;
+        take_profit?: number;
+        stop_loss?: number;
+        trailing_stop?: number;
+        tp_trigger_by?: string;
+        sl_trigger_by?: string;
+        sl_size?: number;
+        tp_size?: number;
+    }): GenericAPIResponse {
+        return this.requestWrapper.post('private/linear/position/trading-stop', params);
+    }
+    
+    getTradeRecords(params: {
+        symbol: string;
+        start_time?: number;
+        end_time?: number;
+        exec_type?: string;
+        page?: integer;
+        limit?: intiger;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('private/linear/trade/execution/list', params);
+    }
+    
+    getClosedPnl(params: {
+        symbol: string;
+        start_time?: number;
+        end_time?: number;
+        exec_type?: string;
+        page?: number;
+        limit?: number;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('private/linear/tpsl/switch-mode', params);
+    }
+    
     //Risk Limit
     //Funding
     //API Key Info

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -116,9 +116,6 @@ export class LinearClient extends SharedEndpoints {
         close_on_trigger?: boolean;
         order_link_id?: string;
     }): GenericAPIResponse {
-        // if (orderRequest.order_type === 'Limit' && !orderRequest.price) {
-        //   throw new Error('Price required for limit orders');
-        // }
         return this.requestWrapper.post('private/linear/order/create', orderRequest);
      }
     
@@ -140,9 +137,6 @@ export class LinearClient extends SharedEndpoints {
         order_id?: string;
         order_link_id?: string;
     }): GenericAPIResponse {
-        // if (!params.order_id && !params.order_link_id) {
-        //   throw new Error('Parameter order_id OR order_link_id is required');
-        // }
         return this.requestWrapper.post('private/linear/order/cancel', params);
     }
     
@@ -163,9 +157,6 @@ export class LinearClient extends SharedEndpoints {
         tp_trigger_by?: string;
         sl_trigger_by?: string;
     }): GenericAPIResponse {
-        // if (!params.order_id && !params.order_link_id) {
-        //   throw new Error('Parameter order_id OR order_link_id is required');
-        // }
         return this.requestWrapper.post('private/linear/order/replace', params);
     }
     
@@ -174,13 +165,81 @@ export class LinearClient extends SharedEndpoints {
         order_link_id?: string;
         symbol: string;
     }): GenericAPIResponse {
-        // if (!params.order_id && !params.order_link_id) {
-        //   throw new Error('Parameter order_id OR order_link_id is required');
-        // }
-        return this.requestWrapper.get('/private/linear/order/search', params);
+        return this.requestWrapper.get('private/linear/order/search', params);
     }
     
     //Conditional Orders
+    
+    placeConditionalOrder(params: {
+        side: string;
+        symbol: string;
+        order_type: string;
+        qty: number;
+        price?: number;
+        base_price: number;
+        stop_px: number;
+        time_in_force: string;
+        trigger_by?: string;
+        close_on_trigger?: boolean;
+        order_link_id?: string;
+        reduce_only: boolean;
+        take_profit?: number;
+        stop_loss?: number;
+        tp_trigger_by?: string;
+        sl_trigger_by?: string;
+    }): GenericAPIResponse {
+        return this.requestWrapper.post('private/linear/stop-order/create', params);
+    }
+    
+    getConditionalOrder(params: {
+        stop_order_id?: string;
+        order_link_id?: string;
+        symbol: string;
+        stop_order_status?: string;
+        order?: string;
+        page?: number;
+        limit?: number;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('private/linear/stop-order/list', params);
+    }
+    
+    cancelConditionalOrder(params: {
+        symbol: string;
+        stop_order_id?: string;
+        order_link_id?: string;
+    }): GenericAPIResponse {
+        return this.requestWrapper.post('private/linear/stop-order/cancel', params);
+    }
+    
+    cancelAllConditionalOrders(params: {
+        symbol: string;
+    }): GenericAPIResponse {
+        return this.requestWrapper.post('private/linear/stop-order/cancel-all', params);
+    }
+    
+    replaceConditionalOrder(params: {
+        stop_order_id?: string;
+        order_link_id?: string;
+        symbol: string;
+        p_r_qty?: number;
+        p_r_price?: number;
+        p_r_trigger_price?: number;
+        take_profit?: number;
+        stop_loss?: number;
+        tp_trigger_by?: string;
+        sl_trigger_by?: string;
+    }): GenericAPIResponse {
+        return this.requestWrapper.post('private/linear/stop-order/replace', params);
+    }
+    
+    queryConditionalOrder(params: {
+        symbol: string;
+        stop_order_id?: string;
+        order_link_id?: string;
+    }): GenericAPIResponse {
+    return this.requestWrapper.get('private/linear/stop-order/search', params);
+    }
+    
     //Position
     //Risk Limit
     //Funding

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -110,7 +110,7 @@ export class LinearClient extends SharedEndpoints {
     order_link_id?: string;
   }): GenericAPIResponse {
     return this.requestWrapper.post('private/linear/order/create', params);
-   }
+  }
 
    getActiveOrderList(params: {
     order_id?: string;

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -4,9 +4,9 @@ import RequestWrapper from './util/requestWrapper';
 import SharedEndpoints from './shared-endpoints';
 
 export class LinearClient extends SharedEndpoints {
-	protected requestWrapper: RequestWrapper;
+  protected requestWrapper: RequestWrapper;
 
-	/**
+  /**
    * @public Creates an instance of the inverse REST API client.
    *
    * @param {string} key - your API key
@@ -16,23 +16,23 @@ export class LinearClient extends SharedEndpoints {
    * @param {AxiosRequestConfig} [requestOptions={}] HTTP networking options for axios
    */
 
-	constructor(
-		key?: string | undefined,
-		secret?: string | undefined,
-		livenet?: boolean,
-		restInverseOptions:RestClientInverseOptions = {}, // TODO: Rename this type to be more general.
-		requestOptions: AxiosRequestConfig = {}
-	) {
-		super()
-		this.requestWrapper = new RequestWrapper(
-			key,
-			secret,
-			getBaseRESTInverseUrl(livenet),
-			restInverseOptions,
-			requestOptions
-		);
-		return this;
-	}
+  constructor(
+    key?: string | undefined,
+    secret?: string | undefined,
+    livenet?: boolean,
+    restInverseOptions:RestClientInverseOptions = {}, // TODO: Rename this type to be more general.
+    requestOptions: AxiosRequestConfig = {}
+  ) {
+    super()
+    this.requestWrapper = new RequestWrapper(
+      key,
+      secret,
+      getBaseRESTInverseUrl(livenet),
+      restInverseOptions,
+      requestOptions
+    );
+    return this;
+  }
 
   /**
    *
@@ -40,66 +40,66 @@ export class LinearClient extends SharedEndpoints {
    *
    */
 
-	getKline(params: {
-		symbol: string;
-		interval: string;
-		from: number;
-		limit?: number;
-	}): GenericAPIResponse {
-		return this.requestWrapper.get('/public/linear/kline', params);
-	}
+  getKline(params: {
+    symbol: string;
+    interval: string;
+    from: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('/public/linear/kline', params);
+  }
 
-	/**
-	* @deprecated use getTrades() instead
-	*/
-	getPublicTradingRecords(params: {
-		symbol: string;
-		from?: number;
-		limit?: number;
-	}): GenericAPIResponse {
-		return this.getTrades(params);
-	}
+  /**
+  * @deprecated use getTrades() instead
+  */
+  getPublicTradingRecords(params: {
+    symbol: string;
+    from?: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.getTrades(params);
+  }
 
-	getTrades(params: {
-		symbol: string;
-		//from?: number;
-		limit?: number;
-	}): GenericAPIResponse {
-		return this.requestWrapper.get('public/linear/recent-trading-records', params);
-	}
+  getTrades(params: {
+    symbol: string;
+    //from?: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('public/linear/recent-trading-records', params);
+  }
 
-	getLastFundingRate(params: {
-	  symbol: string;
-	}): GenericAPIResponse {
-	  return this.requestWrapper.get('public/linear/funding/prev-funding-rate', params);
-	}
+  getLastFundingRate(params: {
+    symbol: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('public/linear/funding/prev-funding-rate', params);
+  }
 
-	getMarkPriceKline(params: {
-		symbol: string;
-		interval: string;
-        from: number;
-		limit?: number;
-	}): GenericAPIResponse {
-		return this.requestWrapper.get('public/linear/mark-price-kline', params);
-	}
-	
-	getIndexPriceKline(params: {
-		symbol: string;
-		interval: string;
-		from: number;
-		limit?: number;
-	}): GenericAPIResponse {
-		return this.requestWrapper.get('public/linear/index-price-kline', params);
-	}
+  getMarkPriceKline(params: {
+    symbol: string;
+    interval: string;
+    from: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('public/linear/mark-price-kline', params);
+  }
+  
+  getIndexPriceKline(params: {
+    symbol: string;
+    interval: string;
+    from: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('public/linear/index-price-kline', params);
+  }
 
-	getPremiumIndexKline(params: {
-		symbol: string;
-		interval: string;
-		from: number;
-		limit?: number;
-	}): GenericAPIResponse {
-		return this.requestWrapper.get('public/linear/premium-index-kline', params);
-	}
+  getPremiumIndexKline(params: {
+    symbol: string;
+    interval: string;
+    from: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('public/linear/premium-index-kline', params);
+  }
 
   /**
    *
@@ -107,251 +107,251 @@ export class LinearClient extends SharedEndpoints {
    *
    */
   
-	//Active Orders
+  //Active Orders
 
-	placeActiveOrder(params: {
-		side: string;
-		symbol: string;
-		order_type: string;
-		qty: number;
-		price?: number;
-		time_in_force: string;
-		take_profit?: number;
-		stop_loss?: number;
-		tp_trigger_by?: string;
-		sl_trigger_by?: string;
-		reduce_only?: boolean;
-		close_on_trigger?: boolean;
-		order_link_id?: string;
-	}): GenericAPIResponse {
-		return this.requestWrapper.post('private/linear/order/create', params);
-	 }
+  placeActiveOrder(params: {
+    side: string;
+    symbol: string;
+    order_type: string;
+    qty: number;
+    price?: number;
+    time_in_force: string;
+    take_profit?: number;
+    stop_loss?: number;
+    tp_trigger_by?: string;
+    sl_trigger_by?: string;
+    reduce_only?: boolean;
+    close_on_trigger?: boolean;
+    order_link_id?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('private/linear/order/create', params);
+   }
 
-	 getActiveOrderList(params: {
-		order_id?: string;
-		order_link_id?: string;
-		symbol: string;
-		order?: string;
-		page?: number;
-		limit?: number;
-		order_status?: string;
+   getActiveOrderList(params: {
+    order_id?: string;
+    order_link_id?: string;
+    symbol: string;
+    order?: string;
+    page?: number;
+    limit?: number;
+    order_status?: string;
 
-	}): GenericAPIResponse {
-		return this.requestWrapper.get('private/linear/order/list', params);
-	}
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('private/linear/order/list', params);
+  }
 
-	cancelActiveOrder(params: {
-		symbol: string;
-		order_id?: string;
-		order_link_id?: string;
-	}): GenericAPIResponse {
-		return this.requestWrapper.post('private/linear/order/cancel', params);
-	}
+  cancelActiveOrder(params: {
+    symbol: string;
+    order_id?: string;
+    order_link_id?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('private/linear/order/cancel', params);
+  }
 
-	cancelAllActiveOrders(params: {
-		symbol: string;
-	}): GenericAPIResponse {
-		return this.requestWrapper.post('private/linear/order/cancel-all', params);
-	}
+  cancelAllActiveOrders(params: {
+    symbol: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('private/linear/order/cancel-all', params);
+  }
 
-	replaceActiveOrder(params: {
-		order_id?: string;
-		order_link_id?: string;
-		symbol: string;
-		p_r_qty?: number;
-		p_r_price?: number;
-		take_profit?: number;
-		stop_loss?: number;
-		tp_trigger_by?: string;
-		sl_trigger_by?: string;
-	}): GenericAPIResponse {
-		return this.requestWrapper.post('private/linear/order/replace', params);
-	}
+  replaceActiveOrder(params: {
+    order_id?: string;
+    order_link_id?: string;
+    symbol: string;
+    p_r_qty?: number;
+    p_r_price?: number;
+    take_profit?: number;
+    stop_loss?: number;
+    tp_trigger_by?: string;
+    sl_trigger_by?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('private/linear/order/replace', params);
+  }
 
-	queryActiveOrder(params: {
-		order_id?: string;
-		order_link_id?: string;
-		symbol: string;
-	}): GenericAPIResponse {
-		return this.requestWrapper.get('private/linear/order/search', params);
-	}
+  queryActiveOrder(params: {
+    order_id?: string;
+    order_link_id?: string;
+    symbol: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('private/linear/order/search', params);
+  }
 
-	//Conditional Orders
+  //Conditional Orders
 
-	placeConditionalOrder(params: {
-		side: string;
-		symbol: string;
-		order_type: string;
-		qty: number;
-		price?: number;
-		base_price: number;
-		stop_px: number;
-		time_in_force: string;
-		trigger_by?: string;
-		close_on_trigger?: boolean;
-		order_link_id?: string;
-		reduce_only: boolean;
-		take_profit?: number;
-		stop_loss?: number;
-		tp_trigger_by?: string;
-		sl_trigger_by?: string;
-	}): GenericAPIResponse {
-		return this.requestWrapper.post('private/linear/stop-order/create', params);
-	}
+  placeConditionalOrder(params: {
+    side: string;
+    symbol: string;
+    order_type: string;
+    qty: number;
+    price?: number;
+    base_price: number;
+    stop_px: number;
+    time_in_force: string;
+    trigger_by?: string;
+    close_on_trigger?: boolean;
+    order_link_id?: string;
+    reduce_only: boolean;
+    take_profit?: number;
+    stop_loss?: number;
+    tp_trigger_by?: string;
+    sl_trigger_by?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('private/linear/stop-order/create', params);
+  }
 
-	getConditionalOrder(params: {
-		stop_order_id?: string;
-		order_link_id?: string;
-		symbol: string;
-		stop_order_status?: string;
-		order?: string;
-		page?: number;
-		limit?: number;
-	}): GenericAPIResponse {
-		return this.requestWrapper.get('private/linear/stop-order/list', params);
-	}
+  getConditionalOrder(params: {
+    stop_order_id?: string;
+    order_link_id?: string;
+    symbol: string;
+    stop_order_status?: string;
+    order?: string;
+    page?: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('private/linear/stop-order/list', params);
+  }
 
-	cancelConditionalOrder(params: {
-		symbol: string;
-		stop_order_id?: string;
-		order_link_id?: string;
-	}): GenericAPIResponse {
-		return this.requestWrapper.post('private/linear/stop-order/cancel', params);
-	}
+  cancelConditionalOrder(params: {
+    symbol: string;
+    stop_order_id?: string;
+    order_link_id?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('private/linear/stop-order/cancel', params);
+  }
 
-	cancelAllConditionalOrders(params: {
-		symbol: string;
-	}): GenericAPIResponse {
-		return this.requestWrapper.post('private/linear/stop-order/cancel-all', params);
-	}
+  cancelAllConditionalOrders(params: {
+    symbol: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('private/linear/stop-order/cancel-all', params);
+  }
 
-	replaceConditionalOrder(params: {
-		stop_order_id?: string;
-		order_link_id?: string;
-		symbol: string;
-		p_r_qty?: number;
-		p_r_price?: number;
-		p_r_trigger_price?: number;
-		take_profit?: number;
-		stop_loss?: number;
-		tp_trigger_by?: string;
-		sl_trigger_by?: string;
-	}): GenericAPIResponse {
-		return this.requestWrapper.post('private/linear/stop-order/replace', params);
-	}
+  replaceConditionalOrder(params: {
+    stop_order_id?: string;
+    order_link_id?: string;
+    symbol: string;
+    p_r_qty?: number;
+    p_r_price?: number;
+    p_r_trigger_price?: number;
+    take_profit?: number;
+    stop_loss?: number;
+    tp_trigger_by?: string;
+    sl_trigger_by?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('private/linear/stop-order/replace', params);
+  }
 
-	queryConditionalOrder(params: {
-		symbol: string;
-		stop_order_id?: string;
-		order_link_id?: string;
-	}): GenericAPIResponse {
-		return this.requestWrapper.get('private/linear/stop-order/search', params);
-	}
+  queryConditionalOrder(params: {
+    symbol: string;
+    stop_order_id?: string;
+    order_link_id?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('private/linear/stop-order/search', params);
+  }
 
-	//Position
+  //Position
 
-	getPosition(params?: {
-		symbol?: string;
-	}): GenericAPIResponse {
-		return this.requestWrapper.get('private/linear/position/list', params);
-	}
+  getPosition(params?: {
+    symbol?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('private/linear/position/list', params);
+  }
 
-	setAutoAddMargin(params?: {
-		symbol: string;
-		side: string;
-		auto_add_margin: boolean;
-	}): GenericAPIResponse {
-		return this.requestWrapper.post('private/linear/position/set-auto-add-margin', params);
-	}
+  setAutoAddMargin(params?: {
+    symbol: string;
+    side: string;
+    auto_add_margin: boolean;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('private/linear/position/set-auto-add-margin', params);
+  }
 
-	setMarginSwitch(params?: {
-		symbol: string;
-		is_isolated: boolean;
-		buy_leverage: number;
-		sell_leverage: number;
-	}): GenericAPIResponse {
-		return this.requestWrapper.post('private/linear/position/switch-isolated', params);
-	}
+  setMarginSwitch(params?: {
+    symbol: string;
+    is_isolated: boolean;
+    buy_leverage: number;
+    sell_leverage: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('private/linear/position/switch-isolated', params);
+  }
 
-	setSwitchMode(params?: {
-		symbol: string;
-		tp_sl_mode: string;
-	}): GenericAPIResponse {
-		return this.requestWrapper.post('private/linear/tpsl/switch-mode', params);
-	}
+  setSwitchMode(params?: {
+    symbol: string;
+    tp_sl_mode: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('private/linear/tpsl/switch-mode', params);
+  }
 
-	setAddReduceMargin(params?: {
-		symbol: string;
-		side: string;
-		margin: number;
-	}): GenericAPIResponse {
-		return this.requestWrapper.post('private/linear/position/add-margin', params);
-	}
+  setAddReduceMargin(params?: {
+    symbol: string;
+    side: string;
+    margin: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('private/linear/position/add-margin', params);
+  }
 
-	setUserLeverage(params: {
-		symbol: string;
-		buy_leverage: number;
-		sell_leverage: number;
-	}): GenericAPIResponse {
-		return this.requestWrapper.post('private/linear/position/set-leverage', params);
-	}
+  setUserLeverage(params: {
+    symbol: string;
+    buy_leverage: number;
+    sell_leverage: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('private/linear/position/set-leverage', params);
+  }
 
-	setTradingStop(params: {
-		symbol: string;
-		side: string;
-		take_profit?: number;
-		stop_loss?: number;
-		trailing_stop?: number;
-		tp_trigger_by?: string;
-		sl_trigger_by?: string;
-		sl_size?: number;
-		tp_size?: number;
-	}): GenericAPIResponse {
-		return this.requestWrapper.post('private/linear/position/trading-stop', params);
-	}
+  setTradingStop(params: {
+    symbol: string;
+    side: string;
+    take_profit?: number;
+    stop_loss?: number;
+    trailing_stop?: number;
+    tp_trigger_by?: string;
+    sl_trigger_by?: string;
+    sl_size?: number;
+    tp_size?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('private/linear/position/trading-stop', params);
+  }
 
-	getTradeRecords(params: {
-		symbol: string;
-		start_time?: number;
-		end_time?: number;
-		exec_type?: string;
-		page?: number;
-		limit?: number;
-	}): GenericAPIResponse {
-		return this.requestWrapper.get('private/linear/trade/execution/list', params);
-	}
+  getTradeRecords(params: {
+    symbol: string;
+    start_time?: number;
+    end_time?: number;
+    exec_type?: string;
+    page?: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('private/linear/trade/execution/list', params);
+  }
 
-	getClosedPnl(params: {
-		symbol: string;
-		start_time?: number;
-		end_time?: number;
-		exec_type?: string;
-		page?: number;
-		limit?: number;
-	}): GenericAPIResponse {
-		return this.requestWrapper.get('private/linear/tpsl/switch-mode', params);
-	}
+  getClosedPnl(params: {
+    symbol: string;
+    start_time?: number;
+    end_time?: number;
+    exec_type?: string;
+    page?: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('private/linear/tpsl/switch-mode', params);
+  }
 
-	//Risk Limit
+  //Risk Limit
 
-	getRiskLimitList(params: {
-		symbol: string;
-	}): GenericAPIResponse {
-		return this.requestWrapper.get('public/linear/risk-limit');
-	}
+  getRiskLimitList(params: {
+    symbol: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('public/linear/risk-limit');
+  }
 
-	//Funding
+  //Funding
 
-	getPredictedFundingFee(params: {
-		symbol: string;
-	}): GenericAPIResponse {
-		return this.requestWrapper.get('private/linear/funding/predicted-funding');
-	}
+  getPredictedFundingFee(params: {
+    symbol: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('private/linear/funding/predicted-funding');
+  }
 
-	getLastFundingFee(params: {
-		symbol: string;
-	}): GenericAPIResponse {
-		return this.requestWrapper.get('private/linear/funding/prev-funding');
-	}
+  getLastFundingFee(params: {
+    symbol: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('private/linear/funding/prev-funding');
+  }
 
 }

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -1,0 +1,47 @@
+import { AxiosRequestConfig } from 'axios';
+import { GenericAPIResponse, getBaseRESTInverseUrl, RestClientInverseOptions } from './util/requestUtils';
+import RequestWrapper from './util/requestWrapper';
+import { SharedEndpoints } from './shared-endpoints';
+
+export class LinearClient extends SharedEndpoints {
+    protected requestWrapper: RequestWrapper;
+
+    /**
+   * @public Creates an instance of the inverse REST API client.
+   *
+   * @param {string} key - your API key
+   * @param {string} secret - your API secret
+   * @param {boolean} [livenet=false]
+   * @param {RestClientInverseOptions} [restInverseOptions={}] options to configure REST API connectivity
+   * @param {AxiosRequestConfig} [requestOptions={}] HTTP networking options for axios
+   */
+
+    constructor(
+        key?: string | undefined,
+        secret?: string | undefined,
+        livenet?: boolean,
+        restInverseOptions:RestClientInverseOptions = {}, // TODO: Rename this type to be more general.
+        requestOptions: AxiosRequestConfig = {}
+      ) {
+        super()
+        this.requestWrapper = new RequestWrapper(
+            key, 
+            secret, 
+            getBaseRESTInverseUrl(livenet), 
+            restInverseOptions, 
+            requestOptions
+        );
+        return this;
+      }
+
+    /**
+   * @public Get the last funding rate.
+   */
+
+    getLastFundingRate(params: {
+      symbol: string;
+    }): GenericAPIResponse {
+      return this.requestWrapper.get('public/linear/funding/prev-funding-rate', params);
+    }
+
+}

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -77,12 +77,12 @@ export class LinearClient extends SharedEndpoints {
 	getMarkPriceKline(params: {
 		symbol: string;
 		interval: string;
-		from: number;
+        from: number;
 		limit?: number;
 	}): GenericAPIResponse {
 		return this.requestWrapper.get('public/linear/mark-price-kline', params);
 	}
-
+	
 	getIndexPriceKline(params: {
 		symbol: string;
 		interval: string;

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -33,6 +33,7 @@ export class LinearClient extends SharedEndpoints {
         );
         return this;
       }
+    
     //------------Market Data Endpoints------------>
     
     getKline(params: {
@@ -95,7 +96,6 @@ export class LinearClient extends SharedEndpoints {
     }): GenericAPIResponse {
         return this.requestWrapper.get('public/linear/premium-index-kline', params);
     }
-    
     
     //-----------Account Data Endpoints------------>
     

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -57,10 +57,10 @@ export class LinearClient extends SharedEndpoints {
 
     getTrades(params: {
         symbol: string;
-        from?: number;
+        //from?: number;
         limit?: number;
     }): GenericAPIResponse {
-        return this.requestWrapper.get('/public/linear/recent-trading-records', params);
+        return this.requestWrapper.get('public/linear/recent-trading-records', params);
     }
     
     getLastFundingRate(params: {
@@ -75,7 +75,7 @@ export class LinearClient extends SharedEndpoints {
         from: number;
         limit?: number;
     }): GenericAPIResponse {
-        return this.requestWrapper.get('/public/linear/mark-price-kline', params);
+        return this.requestWrapper.get('public/linear/mark-price-kline', params);
     }
     
     getIndexPriceKline(params: {
@@ -84,7 +84,7 @@ export class LinearClient extends SharedEndpoints {
         from: number;
         limit?: number;
     }): GenericAPIResponse {
-        return this.requestWrapper.get('/public/linear/index-price-kline', params);
+        return this.requestWrapper.get('public/linear/index-price-kline', params);
     }
     
     getPremiumIndexKline(params: {
@@ -93,11 +93,98 @@ export class LinearClient extends SharedEndpoints {
         from: number;
         limit?: number;
     }): GenericAPIResponse {
-        return this.requestWrapper.get('/public/linear/premium-index-kline', params);
+        return this.requestWrapper.get('public/linear/premium-index-kline', params);
     }
     
     
-    //-----------Account Data Endpoints------------>
+    //-----------Account Data Endpoints------------>   
+    
+    //Active Orders
+    
+    placeActiveOrder(orderRequest: {
+        side: string;
+        symbol: string;
+        order_type: string;
+        qty: number;
+        price?: number;
+        time_in_force: string;
+        take_profit?: number;
+        stop_loss?: number;
+        tp_trigger_by?: string;
+        sl_trigger_by?: string;
+        reduce_only?: boolean;
+        close_on_trigger?: boolean;
+        order_link_id?: string;
+    }): GenericAPIResponse {
+        // if (orderRequest.order_type === 'Limit' && !orderRequest.price) {
+        //   throw new Error('Price required for limit orders');
+        // }
+        return this.requestWrapper.post('private/linear/order/create', orderRequest);
+     }
+    
+     getActiveOrderList(params: {
+        order_id?: string;
+        order_link_id?: string;
+        symbol: string;
+        order?: string;
+        page?: number;
+        limit?: number;
+        order_status?: string;
+        
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('private/linear/order/list', params);
+    }
+    
+    cancelActiveOrder(params: {
+        symbol: string;
+        order_id?: string;
+        order_link_id?: string;
+    }): GenericAPIResponse {
+        // if (!params.order_id && !params.order_link_id) {
+        //   throw new Error('Parameter order_id OR order_link_id is required');
+        // }
+        return this.requestWrapper.post('private/linear/order/cancel', params);
+    }
+    
+    cancelAllActiveOrders(params: {
+        symbol: string;
+    }): GenericAPIResponse {
+        return this.requestWrapper.post('private/linear/order/cancel-all', params);
+    }
+    
+    replaceActiveOrder(params: {
+        order_id?: string;
+        order_link_id?: string;
+        symbol: string;
+        p_r_qty?: number;
+        p_r_price?: number;
+        take_profit?: number;
+        stop_loss?: number;
+        tp_trigger_by?: string;
+        sl_trigger_by?: string;
+    }): GenericAPIResponse {
+        // if (!params.order_id && !params.order_link_id) {
+        //   throw new Error('Parameter order_id OR order_link_id is required');
+        // }
+        return this.requestWrapper.post('private/linear/order/replace', params);
+    }
+    
+    queryActiveOrder(params: {
+        order_id?: string;
+        order_link_id?: string;
+        symbol: string;
+    }): GenericAPIResponse {
+        // if (!params.order_id && !params.order_link_id) {
+        //   throw new Error('Parameter order_id OR order_link_id is required');
+        // }
+        return this.requestWrapper.get('/private/linear/order/search', params);
+    }
+    
+    //Conditional Orders
+    //Position
+    //Risk Limit
+    //Funding
+    //API Key Info
     
     //------------Wallet Data Endpoints------------>
     

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -97,7 +97,7 @@ export class LinearClient extends SharedEndpoints {
     }
     
     
-    //-----------Account Data Endpoints------------>   
+    //-----------Account Data Endpoints------------>
     
     //Active Orders
     

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -106,8 +106,10 @@ export class LinearClient extends SharedEndpoints {
    * Account Data Endpoints
    *
    */
-  
-  //Active Orders
+
+	/**
+   * Active orders
+   */
 
   placeActiveOrder(params: {
     side: string;
@@ -176,7 +178,9 @@ export class LinearClient extends SharedEndpoints {
     return this.requestWrapper.get('private/linear/order/search', params);
   }
 
-  //Conditional Orders
+	/**
+   * Conditional orders
+   */
 
   placeConditionalOrder(params: {
     side: string;
@@ -248,7 +252,9 @@ export class LinearClient extends SharedEndpoints {
     return this.requestWrapper.get('private/linear/stop-order/search', params);
   }
 
-  //Position
+  /**
+   * Position
+   */
 
   getPosition(params?: {
     symbol?: string;
@@ -332,7 +338,9 @@ export class LinearClient extends SharedEndpoints {
     return this.requestWrapper.get('private/linear/tpsl/switch-mode', params);
   }
 
-  //Risk Limit
+	/**
+   * Risk Limit
+   */
 
   getRiskLimitList(params: {
     symbol: string;
@@ -340,7 +348,9 @@ export class LinearClient extends SharedEndpoints {
     return this.requestWrapper.get('public/linear/risk-limit');
   }
 
-  //Funding
+	/**
+   * Funding
+   */
 
   getPredictedFundingFee(params: {
     symbol: string;

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -1,9 +1,9 @@
 import { AxiosRequestConfig } from 'axios';
 import { GenericAPIResponse, getBaseRESTInverseUrl, RestClientInverseOptions } from './util/requestUtils';
 import RequestWrapper from './util/requestWrapper';
-import { SharedEndpoints } from './shared-endpoints';
+import SharedEndpoints from './shared-endpoints';
 
-export class LinearClient extends SharedEndpoints {
+export default class LinearClient extends SharedEndpoints {
     protected requestWrapper: RequestWrapper;
 
     /**

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -48,20 +48,8 @@ export class LinearClient extends SharedEndpoints {
     return this.requestWrapper.get('public/linear/kline', params);
   }
 
-  /**
-  * @deprecated use getTrades() instead
-  */
-  getPublicTradingRecords(params: {
-    symbol: string;
-    from?: number;
-    limit?: number;
-  }): GenericAPIResponse {
-    return this.getTrades(params);
-  }
-
   getTrades(params: {
     symbol: string;
-    //from?: number;
     limit?: number;
   }): GenericAPIResponse {
     return this.requestWrapper.get('public/linear/recent-trading-records', params);
@@ -106,10 +94,6 @@ export class LinearClient extends SharedEndpoints {
    *
    */
 
-	/**
-   * Active orders
-   */
-
   placeActiveOrder(params: {
     side: string;
     symbol: string;
@@ -136,7 +120,6 @@ export class LinearClient extends SharedEndpoints {
     page?: number;
     limit?: number;
     order_status?: string;
-
   }): GenericAPIResponse {
     return this.requestWrapper.get('private/linear/order/list', params);
   }
@@ -344,7 +327,15 @@ export class LinearClient extends SharedEndpoints {
   getRiskLimitList(params: {
     symbol: string;
   }): GenericAPIResponse {
-    return this.requestWrapper.get('public/linear/risk-limit');
+    return this.requestWrapper.get('public/linear/risk-limit', params);
+  }
+
+  setRiskLimit(params: {
+    symbol: string;
+    side: string;
+    risk_id: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('private/linear/position/set-risk', params);
   }
 
 	/**
@@ -354,13 +345,12 @@ export class LinearClient extends SharedEndpoints {
   getPredictedFundingFee(params: {
     symbol: string;
   }): GenericAPIResponse {
-    return this.requestWrapper.get('private/linear/funding/predicted-funding');
+    return this.requestWrapper.get('private/linear/funding/predicted-funding', params);
   }
 
   getLastFundingFee(params: {
     symbol: string;
   }): GenericAPIResponse {
-    return this.requestWrapper.get('private/linear/funding/prev-funding');
+    return this.requestWrapper.get('private/linear/funding/prev-funding', params);
   }
-
 }

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -325,13 +325,25 @@ export class LinearClient extends SharedEndpoints {
     }
     
     //Risk Limit
+    
+    getRiskLimitList(params: {
+        symbol: string;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('public/linear/risk-limit');
+    }
+    
     //Funding
-    //API Key Info
     
-    //------------Wallet Data Endpoints------------>
+    getPredictedFundingFee(params: {
+        symbol: string;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('private/linear/funding/predicted-funding');
+    }
     
-    //-------------API Data Endpoints-------------->
-    
-    
+    getLastFundingFee(params: {
+        symbol: string;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('private/linear/funding/prev-funding');
+    }
     
 }

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig } from 'axios';
-import { GenericAPIResponse, getBaseRESTInverseUrl, RestClientInverseOptions } from './util/requestUtils';
+import { GenericAPIResponse, getRestBaseUrl, RestClientOptions } from './util/requestUtils';
 import RequestWrapper from './util/requestWrapper';
 import SharedEndpoints from './shared-endpoints';
 
@@ -11,23 +11,22 @@ export class LinearClient extends SharedEndpoints {
    *
    * @param {string} key - your API key
    * @param {string} secret - your API secret
-   * @param {boolean} [livenet=false]
-   * @param {RestClientInverseOptions} [restInverseOptions={}] options to configure REST API connectivity
+   * @param {boolean} [useLivenet=false]
+   * @param {RestClientOptions} [restInverseOptions={}] options to configure REST API connectivity
    * @param {AxiosRequestConfig} [requestOptions={}] HTTP networking options for axios
    */
-
   constructor(
     key?: string | undefined,
     secret?: string | undefined,
-    livenet?: boolean,
-    restInverseOptions:RestClientInverseOptions = {}, // TODO: Rename this type to be more general.
+    useLivenet?: boolean,
+    restInverseOptions: RestClientOptions = {},
     requestOptions: AxiosRequestConfig = {}
   ) {
     super()
     this.requestWrapper = new RequestWrapper(
       key,
       secret,
-      getBaseRESTInverseUrl(livenet),
+      getRestBaseUrl(useLivenet),
       restInverseOptions,
       requestOptions
     );
@@ -46,7 +45,7 @@ export class LinearClient extends SharedEndpoints {
     from: number;
     limit?: number;
   }): GenericAPIResponse {
-    return this.requestWrapper.get('/public/linear/kline', params);
+    return this.requestWrapper.get('public/linear/kline', params);
   }
 
   /**
@@ -82,7 +81,7 @@ export class LinearClient extends SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('public/linear/mark-price-kline', params);
   }
-  
+
   getIndexPriceKline(params: {
     symbol: string;
     interval: string;

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -34,7 +34,11 @@ export class LinearClient extends SharedEndpoints {
 		return this;
 	}
 
-	//------------Market Data Endpoints------------>
+  /**
+   *
+   * Market Data Endpoints
+   *
+   */
 
 	getKline(params: {
 		symbol: string;
@@ -97,8 +101,12 @@ export class LinearClient extends SharedEndpoints {
 		return this.requestWrapper.get('public/linear/premium-index-kline', params);
 	}
 
-	//------------Account Data Endpoints------------>
-
+  /**
+   *
+   * Account Data Endpoints
+   *
+   */
+  
 	//Active Orders
 
 	placeActiveOrder(params: {

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -25,10 +25,10 @@ export class LinearClient extends SharedEndpoints {
       ) {
         super()
         this.requestWrapper = new RequestWrapper(
-            key, 
-            secret, 
-            getBaseRESTInverseUrl(livenet), 
-            restInverseOptions, 
+            key,
+            secret,
+            getBaseRESTInverseUrl(livenet),
+            restInverseOptions,
             requestOptions
         );
         return this;

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -33,15 +33,76 @@ export class LinearClient extends SharedEndpoints {
         );
         return this;
       }
-
+    //------------Market Data Endpoints------------>
+    
+    getKline(params: {
+        symbol: string;
+        interval: string;
+        from: number;
+        limit?: number;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('/public/linear/kline', params);
+    }
+   
     /**
-   * @public Get the last funding rate.
-   */
+    * @deprecated use getTrades() instead
+    */
+    getPublicTradingRecords(params: {
+        symbol: string;
+        from?: number;
+        limit?: number;
+    }): GenericAPIResponse {
+        return this.getTrades(params);
+    }
 
+    getTrades(params: {
+        symbol: string;
+        from?: number;
+        limit?: number;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('/public/linear/recent-trading-records', params);
+    }
+    
     getLastFundingRate(params: {
       symbol: string;
     }): GenericAPIResponse {
       return this.requestWrapper.get('public/linear/funding/prev-funding-rate', params);
     }
-
+    
+    getMarkPriceKline(params: {
+        symbol: string;
+        interval: string;
+        from: number;
+        limit?: number;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('/public/linear/mark-price-kline', params);
+    }
+    
+    getIndexPriceKline(params: {
+        symbol: string;
+        interval: string;
+        from: number;
+        limit?: number;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('/public/linear/index-price-kline', params);
+    }
+    
+    getPremiumIndexKline(params: {
+        symbol: string;
+        interval: string;
+        from: number;
+        limit?: number;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('/public/linear/premium-index-kline', params);
+    }
+    
+    
+    //-----------Account Data Endpoints------------>
+    
+    //------------Wallet Data Endpoints------------>
+    
+    //-------------API Data Endpoints-------------->
+    
+    
+    
 }

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -320,9 +320,9 @@ export class LinearClient extends SharedEndpoints {
     return this.requestWrapper.get('private/linear/tpsl/switch-mode', params);
   }
 
-	/**
-   * Risk Limit
-   */
+  /**
+  * Risk Limit
+  */
 
   getRiskLimitList(params: {
     symbol: string;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,7 @@
 export type LogParams = null | any;
 
+export type Logger = typeof DefaultLogger;
+
 export const DefaultLogger = {
   silly: (...params: LogParams): void => {
     console.log(params);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,7 +1,5 @@
 export type LogParams = null | any;
 
-export type Logger = typeof DefaultLogger;
-
 export const DefaultLogger = {
   silly: (...params: LogParams): void => {
     console.log(params);

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -132,4 +132,12 @@ export default class SharedEndpoints {
     getApiAnnouncements(): GenericAPIResponse {
         return this.requestWrapper.get('v2/public/announcement');
     }
+
+    async getTimeOffset(): Promise<number> {
+        const start = Date.now();
+        return this.getServerTime().then(result => {
+          const end = Date.now();
+          return Math.ceil((result.time_now * 1000) - end + ((end - start) / 2));
+        });
+    }
 }

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -5,7 +5,11 @@ export default class SharedEndpoints {
   // TODO: Is there a way to say that Base has to provide this?
   protected requestWrapper: RequestWrapper;
 
-  //------------Market Data Endpoints------------>
+  /**
+   *
+   * Market Data Endpoints
+   *
+   */
 
   getOrderBook(params: {
     symbol: string;
@@ -56,13 +60,21 @@ export default class SharedEndpoints {
     return this.requestWrapper.get('v2/public/account-ratio', params);
   }
 
-  //------------Account Data Endpoints------------>
+  /**
+   *
+   * Account Data Endpoints
+   *
+   */
 
   getApiKeyInfo(): GenericAPIResponse {
     return this.requestWrapper.get('v2/private/account/api-key');
   }
 
-  //------------Wallet Data Endpoints------------>
+  /**
+   *
+   * Wallet Data Endpoints
+   *
+   */
 
   getWalletBalance(params: {
     coin?: string;
@@ -101,7 +113,11 @@ export default class SharedEndpoints {
     return this.requestWrapper.get('v2/private/wallet/withdraw/list', params);
   }
 
-  //-------------API Data Endpoints------------->
+   /**
+   *
+   * API Data Endpoints
+   *
+   */
 
   getServerTime(): GenericAPIResponse {
     return this.requestWrapper.get('v2/public/time');

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -110,14 +110,6 @@ export default class SharedEndpoints {
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/private/wallet/withdraw/list', params);
   }
-  
-  getAssetExchangeRecords(params?: {
-    limit?: number;
-    from?: number;
-    direction?: string;
-  }): GenericAPIResponse {
-    return this.requestWrapper.get('v2/private/exchange-order/list', params);
-  }
 
   getAssetExchangeRecords(params?: {
     limit?: number;

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -116,14 +116,14 @@ export default class SharedEndpoints {
       }): GenericAPIResponse {
         return this.requestWrapper.get('v2/private/wallet/withdraw/list', params);
       }
+    
+    //-------------API Data Endpoints-------------->
 
-      //-------------API Data Endpoints-------------->
-
-      getServerTime(): GenericAPIResponse {
+    getServerTime(): GenericAPIResponse {
         return this.requestWrapper.get('v2/public/time');
-      }
+    }
 
-      getApiAnnouncements(): GenericAPIResponse {
+    getApiAnnouncements(): GenericAPIResponse {
         return this.requestWrapper.get('v2/public/announcement');
-      }
+    }
 }

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -2,7 +2,7 @@
 import { GenericAPIResponse } from './util/requestUtils';
 import RequestWrapper from './util/requestWrapper';
 
-export class SharedEndpoints {
+export default class SharedEndpoints {
     protected requestWrapper: RequestWrapper; // XXX Is there a way to say that Base has to provide this?
 
     

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -113,7 +113,7 @@ export default class SharedEndpoints {
     return this.requestWrapper.get('v2/private/wallet/withdraw/list', params);
   }
 
-   /**
+  /**
    *
    * API Data Endpoints
    *
@@ -127,7 +127,7 @@ export default class SharedEndpoints {
     return this.requestWrapper.get('v2/public/announcement');
   }
 
-  async getTimeOffset(): Promise < number > {
+  async getTimeOffset(): Promise<number> {
     const start = Date.now();
     return this.getServerTime().then(result => {
       const end = Date.now();

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -22,19 +22,6 @@ export default class SharedEndpoints {
     getSymbols(): GenericAPIResponse {
         return this.requestWrapper.get('v2/public/symbols');
     }
-    
-    /**
-    * @deprecated use getLiquidations() instead
-    */
-    getPublicLiquidations(params: {
-        symbol: string;
-        from?: number;
-        limit?: number;
-        start_time?: number;
-        end_time?: number;
-    }): GenericAPIResponse {
-        return this.getLiquidations(params);
-    }
 
     getLiquidations(params: {
         symbol: string;

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -82,14 +82,6 @@ export default class SharedEndpoints {
     return this.requestWrapper.get('v2/private/wallet/balance', params)
   }
 
-  getAssetExchangeRecords(params?: {
-    limit?: number;
-    from?: number;
-    direction?: string;
-  }): GenericAPIResponse {
-    return this.requestWrapper.get('v2/private/exchange-order/list', params);
-  }
-
   getWalletFundRecords(params?: {
     start_date?: string;
     end_date?: string;
@@ -111,6 +103,14 @@ export default class SharedEndpoints {
     limit?: number;
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/private/wallet/withdraw/list', params);
+  }
+
+  getAssetExchangeRecords(params?: {
+    limit?: number;
+    from?: number;
+    direction?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/private/exchange-order/list', params);
   }
 
   /**

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -87,7 +87,7 @@ export default class SharedEndpoints {
     //------------Wallet Data Endpoints------------>
     
     getWalletBalance(params: {
-        coin: string;
+        coin?: string;
     }): GenericAPIResponse {
         return this.requestWrapper.get('v2/private/wallet/balance',params)
     }

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -12,15 +12,6 @@ export default class SharedEndpoints {
     }): GenericAPIResponse {
         return this.requestWrapper.get('v2/public/orderBook/L2', params);
     }
-    
-    /**
-    * @deprecated use getTickers() instead
-    */
-    getLatestInformation(params?: {
-        symbol?: string;
-    }): GenericAPIResponse {
-        return this.getTickers(params);
-    }
 
     getTickers(params?: {
         symbol?: string;

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -56,7 +56,7 @@ export default class SharedEndpoints {
         return this.requestWrapper.get('v2/public/account-ratio', params);
     }
     
-    //------------Market Data Endpoints------------>
+    //------------Account Data Endpoints------------>
     
     getApiKeyInfo(): GenericAPIResponse {
         return this.requestWrapper.get('v2/private/account/api-key');

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -78,6 +78,12 @@ export default class SharedEndpoints {
         return this.requestWrapper.get('v2/public/account-ratio', params);
     }
     
+    //------------Market Data Endpoints------------>
+    
+    getApiKeyInfo(): GenericAPIResponse {
+        return this.requestWrapper.get('v2/private/account/api-key');
+    }
+    
     //------------Wallet Data Endpoints------------>
     
     getWalletBalance(params: {

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -37,6 +37,12 @@ export default class SharedEndpoints {
     return this.requestWrapper.get('v2/public/liq-records', params);
   }
 
+  /**
+   *
+   * Market Data : Advanced
+   *
+   */
+
   getOpenInterest(params: {
     symbol: string;
     period: string;

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -28,6 +28,33 @@ export default class SharedEndpoints {
         return this.requestWrapper.get('v2/public/tickers', params);
     }
     
+    getSymbols(): GenericAPIResponse {
+        return this.requestWrapper.get('v2/public/symbols');
+    }
+    
+    /**
+    * @deprecated use getLiquidations() instead
+    */
+    getPublicLiquidations(params: {
+        symbol: string;
+        from?: number;
+        limit?: number;
+        start_time?: number;
+        end_time?: number;
+    }): GenericAPIResponse {
+        return this.getLiquidations(params);
+    }
+
+    getLiquidations(params: {
+        symbol: string;
+        from?: number;
+        limit?: number;
+        start_time?: number;
+        end_time?: number;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('v2/public/liq-records', params);
+    }
+    
     //------------Wallet Data Endpoints------------>
     
     getWalletBalance(params: {

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -4,8 +4,29 @@ import RequestWrapper from './util/requestWrapper';
 
 export default class SharedEndpoints {
     protected requestWrapper: RequestWrapper; // XXX Is there a way to say that Base has to provide this?
-
     
+    //------------Market Data Endpoints------------>
+    
+    getOrderBook(params: {
+        symbol: string;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('v2/public/orderBook/L2', params);
+    }
+    
+    /**
+    * @deprecated use getTickers() instead
+    */
+    getLatestInformation(params?: {
+        symbol?: string;
+    }): GenericAPIResponse {
+        return this.getTickers(params);
+    }
+
+    getTickers(params?: {
+        symbol?: string;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('v2/public/tickers', params);
+    }
     
     //------------Wallet Data Endpoints------------>
     

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -1,121 +1,121 @@
-//type Constructor = new (...args: any[]) => {};
 import { GenericAPIResponse } from './util/requestUtils';
 import RequestWrapper from './util/requestWrapper';
 
 export default class SharedEndpoints {
-    protected requestWrapper: RequestWrapper; // XXX Is there a way to say that Base has to provide this?
-    
-    //------------Market Data Endpoints------------>
-    
-    getOrderBook(params: {
-        symbol: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('v2/public/orderBook/L2', params);
-    }
+  // TODO: Is there a way to say that Base has to provide this?
+  protected requestWrapper: RequestWrapper;
 
-    getTickers(params?: {
-        symbol?: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('v2/public/tickers', params);
-    }
-    
-    getSymbols(): GenericAPIResponse {
-        return this.requestWrapper.get('v2/public/symbols');
-    }
+  //------------Market Data Endpoints------------>
 
-    getLiquidations(params: {
-        symbol: string;
-        from?: number;
-        limit?: number;
-        start_time?: number;
-        end_time?: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('v2/public/liq-records', params);
-    }
-    
-    getOpenInterest(params: {
-        symbol: string;
-        period: string;
-        limit?: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('v2/public/open-interest', params);
-    }
+  getOrderBook(params: {
+    symbol: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/orderBook/L2', params);
+  }
 
-    getLatestBigDeal(params: {
-        symbol: string;
-        limit?: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('v2/public/big-deal', params);
-    }
+  getTickers(params?: {
+    symbol?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/tickers', params);
+  }
 
-    getLongShortRatio(params: {
-        symbol: string;
-        period: string;
-        limit?: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('v2/public/account-ratio', params);
-    }
-    
-    //------------Account Data Endpoints------------>
-    
-    getApiKeyInfo(): GenericAPIResponse {
-        return this.requestWrapper.get('v2/private/account/api-key');
-    }
-    
-    //------------Wallet Data Endpoints------------>
-    
-    getWalletBalance(params: {
-        coin?: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('v2/private/wallet/balance',params)
-    }
+  getSymbols(): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/symbols');
+  }
 
-    getAssetExchangeRecords(params?: {
-        limit?: number;
-        from?: number;
-        direction?: string;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('v2/private/exchange-order/list', params);
-    }
+  getLiquidations(params: {
+    symbol: string;
+    from?: number;
+    limit?: number;
+    start_time?: number;
+    end_time?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/liq-records', params);
+  }
 
-    getWalletFundRecords(params?: {
-        start_date?: string;
-        end_date?: string;
-        currency?: string;
-        coin?: string;
-        wallet_fund_type?: string;
-        page?: number;
-        limit?: number;
-    }): GenericAPIResponse {
-        return this.requestWrapper.get('v2/private/wallet/fund/records', params);
-    }
+  getOpenInterest(params: {
+    symbol: string;
+    period: string;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/open-interest', params);
+  }
 
-    getWithdrawRecords(params: {
-        start_date?: string;
-        end_date?: string;
-        coin?: string;
-        status?: string;
-        page?: number;
-        limit?: number;
-      }): GenericAPIResponse {
-        return this.requestWrapper.get('v2/private/wallet/withdraw/list', params);
-      }
-    
-    //-------------API Data Endpoints------------->
+  getLatestBigDeal(params: {
+    symbol: string;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/big-deal', params);
+  }
 
-    getServerTime(): GenericAPIResponse {
-        return this.requestWrapper.get('v2/public/time');
-    }
+  getLongShortRatio(params: {
+    symbol: string;
+    period: string;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/account-ratio', params);
+  }
 
-    getApiAnnouncements(): GenericAPIResponse {
-        return this.requestWrapper.get('v2/public/announcement');
-    }
+  //------------Account Data Endpoints------------>
 
-    async getTimeOffset(): Promise<number> {
-        const start = Date.now();
-        return this.getServerTime().then(result => {
-          const end = Date.now();
-          return Math.ceil((result.time_now * 1000) - end + ((end - start) / 2));
-        });
-    }
+  getApiKeyInfo(): GenericAPIResponse {
+    return this.requestWrapper.get('v2/private/account/api-key');
+  }
+
+  //------------Wallet Data Endpoints------------>
+
+  getWalletBalance(params: {
+    coin?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/private/wallet/balance', params)
+  }
+
+  getAssetExchangeRecords(params?: {
+    limit?: number;
+    from?: number;
+    direction?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/private/exchange-order/list', params);
+  }
+
+  getWalletFundRecords(params?: {
+    start_date?: string;
+    end_date?: string;
+    currency?: string;
+    coin?: string;
+    wallet_fund_type?: string;
+    page?: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/private/wallet/fund/records', params);
+  }
+
+  getWithdrawRecords(params: {
+    start_date?: string;
+    end_date?: string;
+    coin?: string;
+    status?: string;
+    page?: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/private/wallet/withdraw/list', params);
+  }
+
+  //-------------API Data Endpoints------------->
+
+  getServerTime(): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/time');
+  }
+
+  getApiAnnouncements(): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/announcement');
+  }
+
+  async getTimeOffset(): Promise < number > {
+    const start = Date.now();
+    return this.getServerTime().then(result => {
+      const end = Date.now();
+      return Math.ceil((result.time_now * 1000) - end + ((end - start) / 2));
+    });
+  }
 }

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -82,14 +82,6 @@ export default class SharedEndpoints {
     return this.requestWrapper.get('v2/private/wallet/balance', params)
   }
 
-  getAssetExchangeRecords(params?: {
-    limit?: number;
-    from?: number;
-    direction?: string;
-  }): GenericAPIResponse {
-    return this.requestWrapper.get('v2/private/exchange-order/list', params);
-  }
-
   getWalletFundRecords(params?: {
     start_date?: string;
     end_date?: string;
@@ -111,6 +103,14 @@ export default class SharedEndpoints {
     limit?: number;
   }): GenericAPIResponse {
     return this.requestWrapper.get('v2/private/wallet/withdraw/list', params);
+  }
+  
+  getAssetExchangeRecords(params?: {
+    limit?: number;
+    from?: number;
+    direction?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/private/exchange-order/list', params);
   }
 
   /**

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -1,0 +1,58 @@
+//type Constructor = new (...args: any[]) => {};
+import { GenericAPIResponse } from './util/requestUtils';
+import RequestWrapper from './util/requestWrapper';
+
+export class SharedEndpoints {
+    protected requestWrapper: RequestWrapper; // XXX Is there a way to say that Base has to provide this?
+
+    
+    
+    //------------Wallet Data Endpoints------------>
+    
+    getWalletBalance(params: {
+        coin: string;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('v2/private/wallet/balance',params)
+    }
+
+    getAssetExchangeRecords(params?: {
+        limit?: number;
+        from?: number;
+        direction?: string;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('v2/private/exchange-order/list', params);
+    }
+
+    getWalletFundRecords(params?: {
+        start_date?: string;
+        end_date?: string;
+        currency?: string;
+        coin?: string;
+        wallet_fund_type?: string;
+        page?: number;
+        limit?: number;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('v2/private/wallet/fund/records', params);
+    }
+
+    getWithdrawRecords(params: {
+        start_date?: string;
+        end_date?: string;
+        coin?: string;
+        status?: string;
+        page?: number;
+        limit?: number;
+      }): GenericAPIResponse {
+        return this.requestWrapper.get('v2/private/wallet/withdraw/list', params);
+      }
+
+      //-------------API Data Endpoints-------------->
+
+      getServerTime(): GenericAPIResponse {
+        return this.requestWrapper.get('v2/public/time');
+      }
+
+      getApiAnnouncements(): GenericAPIResponse {
+        return this.requestWrapper.get('v2/public/announcement');
+      }
+}

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -55,6 +55,29 @@ export default class SharedEndpoints {
         return this.requestWrapper.get('v2/public/liq-records', params);
     }
     
+    getOpenInterest(params: {
+        symbol: string;
+        period: string;
+        limit?: number;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('v2/public/open-interest', params);
+    }
+
+    getLatestBigDeal(params: {
+        symbol: string;
+        limit?: number;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('v2/public/big-deal', params);
+    }
+
+    getLongShortRatio(params: {
+        symbol: string;
+        period: string;
+        limit?: number;
+    }): GenericAPIResponse {
+        return this.requestWrapper.get('v2/public/account-ratio', params);
+    }
+    
     //------------Wallet Data Endpoints------------>
     
     getWalletBalance(params: {

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -101,7 +101,7 @@ export default class SharedEndpoints {
         return this.requestWrapper.get('v2/private/wallet/withdraw/list', params);
       }
     
-    //-------------API Data Endpoints-------------->
+    //-------------API Data Endpoints------------->
 
     getServerTime(): GenericAPIResponse {
         return this.requestWrapper.get('v2/public/time');

--- a/src/util/WsStore.ts
+++ b/src/util/WsStore.ts
@@ -1,6 +1,7 @@
 import { WsConnectionState } from '../websocket-client';
 import { DefaultLogger, Logger } from '../logger';
 
+import WebSocket from 'isomorphic-ws';
 
 type WsTopicList = Set<string>;
 type KeyedWsTopicLists = {

--- a/src/util/WsStore.ts
+++ b/src/util/WsStore.ts
@@ -1,0 +1,63 @@
+import { DefaultLogger, Logger } from '../logger';
+
+export enum WsConnectionState {
+  READY_STATE_INITIAL,
+  READY_STATE_CONNECTING,
+  READY_STATE_CONNECTED,
+  READY_STATE_CLOSING,
+  READY_STATE_RECONNECTING
+};
+
+export default class WsStore {
+  private connections: {
+    [key: string]: WebSocket
+  };
+  private connectionState: {
+    [key: string]: WsConnectionState
+  }
+  private logger: Logger;
+
+  constructor(logger: Logger) {
+    this.connections = {}
+    this.connectionState = {};
+    this.logger = logger || DefaultLogger;
+  }
+
+  getConnection(key: string) {
+    return this.connections[key];
+  }
+
+  setConnection(key: string, wsConnection: WebSocket) {
+    const existingConnection = this.getConnection(key);
+    if (existingConnection) {
+      this.logger.info('WsStore setConnection() overwriting existing connection: ', existingConnection);
+    }
+    this.connections[key] = wsConnection;
+  }
+
+  clearConnection(key: string) {
+    const existingConnection = this.getConnection(key);
+    if (existingConnection) {
+      delete this.connections[key];
+    }
+  }
+
+  getConnectionState(key: string) {
+    return this.connectionState[key];
+  }
+
+  setConnectionState(key: string, state: WsConnectionState) {
+    this.connectionState[key] = state;
+  }
+
+  isConnectionState(key: string, state: WsConnectionState) {
+    const a = this.getConnectionState(key) === state;
+    const b = this.getConnectionState(key) == state;
+    if (a != b) {
+      console.error('connection state doesnt match: ', { state, storedState: this.getConnectionState(key) });
+    } else {
+      console.log('isConnectionState matches');
+    }
+    return this.getConnectionState(key) === state;
+  }
+}

--- a/src/util/WsStore.ts
+++ b/src/util/WsStore.ts
@@ -1,12 +1,18 @@
 import { WsConnectionState } from '../websocket-client';
 import { DefaultLogger, Logger } from '../logger';
 
+
+type WsTopicList = Set<string>;
+type KeyedWsTopicLists = {
+  [key: string]: WsTopicList;
+};
+
 interface WsStoredState {
   ws?: WebSocket;
   connectionState?: WsConnectionState;
   activePingTimer?: NodeJS.Timeout | undefined;
   activePongTimer?: NodeJS.Timeout | undefined;
-  subscribedTopics: Set<string>;
+  subscribedTopics: WsTopicList;
 };
 
 export default class WsStore {
@@ -30,6 +36,10 @@ export default class WsStore {
     }
 
     return undefined;
+  }
+
+  getKeys(): string[] {
+    return Object.keys(this.wsState);
   }
 
   create(key: string): WsStoredState | undefined {
@@ -91,8 +101,16 @@ export default class WsStore {
 
   /* subscribed topics */
 
-  getTopics(key: string): Set<string> {
+  getTopics(key: string): WsTopicList {
     return this.get(key, true)!.subscribedTopics;
+  }
+
+  getTopicsByKey(): KeyedWsTopicLists {
+    const result = {};
+    for (const refKey in this.wsState) {
+      result[refKey] = this.getTopics(refKey);
+    }
+    return result;
   }
 
   addTopic(key: string, topic: string) {

--- a/src/util/WsStore.ts
+++ b/src/util/WsStore.ts
@@ -1,5 +1,5 @@
 import { WsConnectionState } from '../websocket-client';
-import { DefaultLogger, Logger } from '../logger';
+import { DefaultLogger } from '../logger';
 
 import WebSocket from 'isomorphic-ws';
 
@@ -20,9 +20,9 @@ export default class WsStore {
   private wsState: {
     [key: string]: WsStoredState;
   }
-  private logger: Logger;
+  private logger: typeof DefaultLogger;
 
-  constructor(logger: Logger) {
+  constructor(logger: typeof DefaultLogger) {
     this.logger = logger || DefaultLogger;
     this.wsState = {};
   }

--- a/src/util/requestUtils.ts
+++ b/src/util/requestUtils.ts
@@ -57,3 +57,13 @@ export function getBaseRESTInverseUrl(useLivenet?: boolean, restInverseOptions?:
   }
   return baseUrlsInverse.testnet;
 }
+      
+export function isPublicEndpoint = (endpoint: string): boolean => {
+  if (endpoint.startsWith('v2/public')) {
+    return true;
+  }
+  if (endpoint.startsWith('public/linear')) {
+    return true;
+  }
+  return false;
+}

--- a/src/util/requestUtils.ts
+++ b/src/util/requestUtils.ts
@@ -1,6 +1,6 @@
 import { createHmac } from 'crypto';
 
-export interface RestClientInverseOptions {
+export interface RestClientOptions {
   // override the max size of the request window (in ms)
   recv_window?: number;
 
@@ -42,7 +42,7 @@ export function serializeParams(params: object = {}, strict_validation = false):
     .join('&');
 };
 
-export function getBaseRESTInverseUrl(useLivenet?: boolean, restInverseOptions?: RestClientInverseOptions) {
+export function getRestBaseUrl(useLivenet?: boolean, restInverseOptions?: RestClientOptions) {
   const baseUrlsInverse = {
     livenet: 'https://api.bybit.com',
     testnet: 'https://api-testnet.bybit.com'

--- a/src/util/requestUtils.ts
+++ b/src/util/requestUtils.ts
@@ -57,7 +57,7 @@ export function getBaseRESTInverseUrl(useLivenet?: boolean, restInverseOptions?:
   }
   return baseUrlsInverse.testnet;
 }
-      
+
 export function isPublicEndpoint (endpoint: string): boolean {
   if (endpoint.startsWith('v2/public')) {
     return true;
@@ -66,4 +66,13 @@ export function isPublicEndpoint (endpoint: string): boolean {
     return true;
   }
   return false;
+}
+
+export function isWsPong(response: any) {
+  return (
+    response.request &&
+    response.request.op === 'ping' &&
+    response.ret_msg === 'pong' &&
+    response.success === true
+  );
 }

--- a/src/util/requestUtils.ts
+++ b/src/util/requestUtils.ts
@@ -58,7 +58,7 @@ export function getBaseRESTInverseUrl(useLivenet?: boolean, restInverseOptions?:
   return baseUrlsInverse.testnet;
 }
       
-export function isPublicEndpoint = (endpoint: string): boolean => {
+export function isPublicEndpoint (endpoint: string): boolean {
   if (endpoint.startsWith('v2/public')) {
     return true;
   }

--- a/src/util/requestWrapper.ts
+++ b/src/util/requestWrapper.ts
@@ -10,6 +10,7 @@ export default class RequestUtil {
   private globalRequestOptions: AxiosRequestConfig;
   private key: string | undefined;
   private secret: string | undefined;
+  //all private
 
   constructor(
     key: string | undefined,
@@ -68,9 +69,15 @@ export default class RequestUtil {
    * @private Make a HTTP request to a specific endpoint. Private endpoints are automatically signed.
    */
   async _call(method: Method, endpoint: string, params?: any): GenericAPIResponse {
-    const publicEndpoint = endpoint.startsWith('v2/public');
+    let publicEndpoint = false;
+    if(endpoint.startsWith('v2/public')){
+      publicEndpoint = true;
+    }
+    else if(endpoint.startsWith('public/linear/')){
+      publicEndpoint = true;
+    }
 
-    if (!publicEndpoint) {
+    if (publicEndpoint == false) {
       if (!this.key || !this.secret) {
         throw new Error('Private endpoints require api and private keys set');
       }
@@ -101,7 +108,7 @@ export default class RequestUtil {
       }
 
       throw response;
-    }).catch(e => this.parseException(e));
+    }).catch(this.parseException);
   }
 
   /**

--- a/src/util/requestWrapper.ts
+++ b/src/util/requestWrapper.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosRequestConfig, AxiosResponse, Method } from 'axios';
 
-import { signMessage, serializeParams, RestClientInverseOptions, GenericAPIResponse } from './requestUtils';
+import { signMessage, serializeParams, RestClientInverseOptions, GenericAPIResponse, isPublicEndpoint } from './requestUtils';
 
 export default class RequestUtil {
   private timeOffset: number | null;
@@ -68,17 +68,7 @@ export default class RequestUtil {
    * @private Make a HTTP request to a specific endpoint. Private endpoints are automatically signed.
    */
   async _call(method: Method, endpoint: string, params?: any): GenericAPIResponse {
-    const isPublicEndpoint = (endpoint: string): boolean => {
-      if (endpoint.startsWith('v2/public')) {
-        return true;
-      }
-      if (endpoint.startsWith('public/linear')) {
-        return true;
-      }
-      return false;
-    }
-
-    if (isPublicEndpoint(endpoint) === false) {
+    if (!isPublicEndpoint(endpoint)) {
       if (!this.key || !this.secret) {
         throw new Error('Private endpoints require api and private keys set');
       }

--- a/src/util/requestWrapper.ts
+++ b/src/util/requestWrapper.ts
@@ -69,7 +69,7 @@ export default class RequestUtil {
    * @private Make a HTTP request to a specific endpoint. Private endpoints are automatically signed.
    */
   async _call(method: Method, endpoint: string, params?: any): GenericAPIResponse {
-    const isPublicEndpoint = (endpoint: string): boolean {
+    const isPublicEndpoint = (endpoint: string): boolean => {
       if (endpoint.startsWith('v2/public')) {
         return true;
       }

--- a/src/util/requestWrapper.ts
+++ b/src/util/requestWrapper.ts
@@ -10,7 +10,6 @@ export default class RequestUtil {
   private globalRequestOptions: AxiosRequestConfig;
   private key: string | undefined;
   private secret: string | undefined;
-  //all private
 
   constructor(
     key: string | undefined,

--- a/src/util/requestWrapper.ts
+++ b/src/util/requestWrapper.ts
@@ -110,7 +110,7 @@ export default class RequestUtil {
       }
 
       throw response;
-    }).catch(this.parseException);
+    }).catch(e => this.parseException(e));
   }
 
   /**

--- a/src/util/requestWrapper.ts
+++ b/src/util/requestWrapper.ts
@@ -69,15 +69,17 @@ export default class RequestUtil {
    * @private Make a HTTP request to a specific endpoint. Private endpoints are automatically signed.
    */
   async _call(method: Method, endpoint: string, params?: any): GenericAPIResponse {
-    let publicEndpoint = false;
-    if(endpoint.startsWith('v2/public')){
-      publicEndpoint = true;
-    }
-    else if(endpoint.startsWith('public/linear/')){
-      publicEndpoint = true;
+    const isPublicEndpoint = (endpoint: string): boolean {
+      if (endpoint.startsWith('v2/public')) {
+        return true;
+      }
+      if (endpoint.startsWith('public/linear')) {
+        return true;
+      }
+      return false;
     }
 
-    if (publicEndpoint == false) {
+    if (isPublicEndpoint(endpoint) === false) {
       if (!this.key || !this.secret) {
         throw new Error('Private endpoints require api and private keys set');
       }

--- a/src/util/requestWrapper.ts
+++ b/src/util/requestWrapper.ts
@@ -1,11 +1,11 @@
 import axios, { AxiosRequestConfig, AxiosResponse, Method } from 'axios';
 
-import { signMessage, serializeParams, RestClientInverseOptions, GenericAPIResponse, isPublicEndpoint } from './requestUtils';
+import { signMessage, serializeParams, RestClientOptions, GenericAPIResponse, isPublicEndpoint } from './requestUtils';
 
 export default class RequestUtil {
   private timeOffset: number | null;
   private syncTimePromise: null | Promise<any>;
-  private options: RestClientInverseOptions;
+  private options: RestClientOptions;
   private baseUrl: string;
   private globalRequestOptions: AxiosRequestConfig;
   private key: string | undefined;
@@ -15,7 +15,7 @@ export default class RequestUtil {
     key: string | undefined,
     secret: string | undefined,
     baseUrl: string,
-    options: RestClientInverseOptions = {},
+    options: RestClientOptions = {},
     requestOptions: AxiosRequestConfig = {}
   ) {
     this.timeOffset = null;

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -45,7 +45,6 @@ export class WebsocketClient extends EventEmitter {
     super();
 
     this.logger = logger || DefaultLogger;
-
     this.readyState = READY_STATE_INITIAL;
     this.pingInterval = undefined;
     this.pongTimeout = undefined;
@@ -60,7 +59,6 @@ export class WebsocketClient extends EventEmitter {
 
     this.client = new InverseClient(undefined, undefined, this.options.livenet, this.options.restOptions, this.options.requestOptions);
     this._subscriptions = new Set();
-
     this._connect();
   }
 
@@ -101,7 +99,6 @@ export class WebsocketClient extends EventEmitter {
 
       const authParams = await this._authenticate();
       const url = this._getWsUrl() + authParams;
-
       const ws = new WebSocket(url);
 
       ws.onopen = this._wsOpenHandler.bind(this);
@@ -110,7 +107,7 @@ export class WebsocketClient extends EventEmitter {
       ws.onclose = this._wsCloseHandler.bind(this);
 
       this.ws = ws;
-
+      
     } catch (err) {
       this.logger.error('Connection failed: ', err);
       this._reconnect(this.options.reconnectTimeout);

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -75,6 +75,16 @@ const getLinearWsKeyForTopic = (topic: string) => {
   return wsKeyLinearPublic;
 }
 
+export declare interface WebsocketClient {
+  on(event: 'open', listener: ({ wsKey: string, event: any }) => void): this;
+  on(event: 'reconnected', listener: ({ wsKey: string, event: any }) => void): this;
+  on(event: 'reconnect', listener: () => void): this;
+  on(event: 'close', listener: () => void): this;
+  on(event: 'response', listener: (response: any) => void): this;
+  on(event: 'update', listener: (response: any) => void): this;
+  on(event: 'error', listener: (response: any) => void): this;
+}
+
 export class WebsocketClient extends EventEmitter {
   private logger: typeof DefaultLogger;
   private restClient: InverseClient | LinearClient;

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -129,7 +129,6 @@ export class WebsocketClient extends EventEmitter {
     this.wsStore.getKeys().forEach(wsKey => {
       // if connected, send subscription request
       if (this.wsStore.isConnectionState(wsKey, READY_STATE_CONNECTED)) {
-        console.log(`${wsKey} is supposedly connected - sending request for topics`);
         return this.requestSubscribeTopics(wsKey, [...this.wsStore.getTopics(wsKey)]);
       }
 
@@ -332,7 +331,7 @@ export class WebsocketClient extends EventEmitter {
     try {
       this.logger.silly(`Sending upstream ws message: `, { ...loggerCategory, wsMessage, wsKey });
       if (!wsKey) {
-        console.error('ws with key: ', wsKey, ' not found');
+        throw new Error('Cannot send message due to no known websocket for this wsKey');
       }
       this.getWs(wsKey)?.send(wsMessage);
     } catch (e) {

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import { InverseClient } from './inverse-client';
 import { LinearClient } from './linear-client';
-import { DefaultLogger, Logger } from './logger';
+import { DefaultLogger } from './logger';
 import { signMessage, serializeParams, isWsPong } from './util/requestUtils';
 
 import WebSocket from 'isomorphic-ws';
@@ -76,12 +76,12 @@ const getLinearWsKeyForTopic = (topic: string) => {
 }
 
 export class WebsocketClient extends EventEmitter {
-  private logger: Logger;
+  private logger: typeof DefaultLogger;
   private restClient: InverseClient | LinearClient;
   private options: WebsocketClientOptions;
   private wsStore: WsStore;
 
-  constructor(options: WSClientConfigurableOptions, logger?: Logger) {
+  constructor(options: WSClientConfigurableOptions, logger?: typeof DefaultLogger) {
     super();
 
     this.logger = logger || DefaultLogger;

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -3,15 +3,15 @@ import { InverseClient } from './inverse-client';
 import { LinearClient } from './linear-client';
 import { DefaultLogger } from './logger';
 import { signMessage, serializeParams } from './util/requestUtils';
-// import WebSocket from 'ws';
+
 import WebSocket from 'isomorphic-ws';
 
-const iwsUrls = {
+const inverseEndpoints = {
   livenet: 'wss://stream.bybit.com/realtime',
   testnet: 'wss://stream-testnet.bybit.com/realtime'
 };
 
-const lwsUrls = {
+const linearEndpoints = {
   livenet: 'wss://stream.bybit.com/realtime_public',
   testnet: 'wss://stream-testnet.bybit.com/realtime_public'
 };
@@ -22,7 +22,15 @@ const READY_STATE_CONNECTED = 2;
 const READY_STATE_CLOSING = 3;
 const READY_STATE_RECONNECTING = 4;
 
-export interface WebsocketClientOptions {
+enum WsConnectionState {
+  READY_STATE_INITIAL,
+  READY_STATE_CONNECTING,
+  READY_STATE_CONNECTED,
+  READY_STATE_CLOSING,
+  READY_STATE_RECONNECTING
+};
+
+export interface WebsocketClientConfigurableOptions {
   key?: string;
   secret?: string;
   livenet?: boolean;
@@ -35,21 +43,27 @@ export interface WebsocketClientOptions {
   wsUrl?: string;
 };
 
+export interface WebsocketClientOptions extends WebsocketClientConfigurableOptions {
+  livenet: boolean;
+  linear: boolean;
+  pongTimeout: number;
+  pingInterval: number;
+  reconnectTimeout: number;
+};
+
 type Logger = typeof DefaultLogger;
-
-
 
 export class WebsocketClient extends EventEmitter {
   private logger: Logger;
-  private readyState: number;
+  private readyState: WsConnectionState;
   private pingInterval?: number | undefined;
   private pongTimeout?: number | undefined;
   private client: InverseClient | LinearClient;
-  private _subscriptions: Set<unknown>;
+  private subcribedTopics: Set<string>;
   private ws: WebSocket;
   private options: WebsocketClientOptions;
 
-  constructor(options: WebsocketClientOptions, logger?: Logger) {
+  constructor(options: WebsocketClientConfigurableOptions, logger?: Logger) {
     super();
 
     this.logger = logger || DefaultLogger;
@@ -68,71 +82,89 @@ export class WebsocketClient extends EventEmitter {
 
 
     if (this.options.linear === true) {
-      this.client = new LinearClient(undefined, undefined, this.options.livenet, this.options.restOptions, this.options.requestOptions);
+      this.client = new LinearClient(undefined, undefined, this.isLivenet(), this.options.restOptions, this.options.requestOptions);
     }else{
-      this.client = new InverseClient(undefined, undefined, this.options.livenet, this.options.restOptions, this.options.requestOptions);
+      this.client = new InverseClient(undefined, undefined, this.isLivenet(), this.options.restOptions, this.options.requestOptions);
     }
-    
-    this._subscriptions = new Set();
-    this._connect();
+
+    this.subcribedTopics = new Set();
+    this.connect();
   }
 
-  subscribe(topics) {
-    if (!Array.isArray(topics)) topics = [topics];
-    topics.forEach(topic => this._subscriptions.add(topic));
-
-    // subscribe not necessary if not yet connected (will subscribe onOpen)
-    if (this.readyState === READY_STATE_CONNECTED) this._subscribe(topics);
+  isLivenet(): boolean {
+    return this.options.livenet === true;
   }
 
-  unsubscribe(topics) {
-    if (!Array.isArray(topics)) topics = [topics];
+  /**
+   * Add topic/topics to WS subscription list
+   */
+  public subscribe(wsTopics: string[] | string) {
+    const topics = Array.isArray(wsTopics) ? wsTopics : [wsTopics];
+    topics.forEach(topic => this.subcribedTopics.add(topic));
 
-    topics.forEach(topic => this._subscriptions.delete(topic));
+    // subscribe not necessary if not yet connected (will automatically subscribe onOpen)
+    if (this.readyState === READY_STATE_CONNECTED) {
+      this.requestSubscribeTopics(topics);
+    }
+  }
+
+  /**
+   * Remove topic/topics from WS subscription list
+   */
+  public unsubscribe(wsTopics: string[] | string) {
+    const topics = Array.isArray(wsTopics) ? wsTopics : [wsTopics];
+    topics.forEach(topic => this.subcribedTopics.delete(topic));
 
     // unsubscribe not necessary if not yet connected
-    if (this.readyState === READY_STATE_CONNECTED) this._unsubscribe(topics);
+    if (this.readyState === READY_STATE_CONNECTED) {
+      this.requestUnsubscribeTopics(topics);
+    }
   }
 
   close() {
     this.logger.info('Closing connection', {category: 'bybit-ws'});
     this.readyState = READY_STATE_CLOSING;
-    this._teardown();
+    this.teardown();
     this.ws && this.ws.close();
   }
 
-  _getWsUrl() {
+  private getWsUrl() {
     if (this.options.wsUrl) {
       return this.options.wsUrl;
     }
     if (this.options.linear){
-        return lwsUrls[this.options.livenet ? 'livenet' : 'testnet'];
+        return linearEndpoints[this.options.livenet ? 'livenet' : 'testnet'];
     }
-    return iwsUrls[this.options.livenet ? 'livenet' : 'testnet'];
+    return inverseEndpoints[this.options.livenet ? 'livenet' : 'testnet'];
   }
 
-  async _connect() {
+  private async connect() {
     try {
-      if (this.readyState === READY_STATE_INITIAL) this.readyState = READY_STATE_CONNECTING;
+      if (this.readyState === READY_STATE_INITIAL) {
+        this.readyState = READY_STATE_CONNECTING;
+      }
 
-      const authParams = await this._authenticate();
-      const url = this._getWsUrl() + authParams;
+      const authParams = await this.getAuthParams();
+      const url = this.getWsUrl() + authParams;
       const ws = new WebSocket(url);
 
-      ws.onopen = this._wsOpenHandler.bind(this);
-      ws.onmessage = this._wsMessageHandler.bind(this);
-      ws.onerror = this._wsOnErrorHandler.bind(this);
-      ws.onclose = this._wsCloseHandler.bind(this);
+      ws.onopen = this.onWsOpen.bind(this);
+      ws.onmessage = this.onWsMessage.bind(this);
+      ws.onerror = this.onWsError.bind(this);
+      ws.onclose = this.onWsClose.bind(this);
 
       this.ws = ws;
-      
+
     } catch (err) {
       this.logger.error('Connection failed: ', err);
-      this._reconnect(this.options.reconnectTimeout);
+      this.reconnectWithDelay(this.options.reconnectTimeout!);
     }
   }
 
-  async _authenticate() {
+  /**
+   * Return params required to make authorized request
+   */
+  private async getAuthParams(): Promise<string> {
     if (this.options.key && this.options.secret) {
       this.logger.debug('Starting authenticated websocket client.', {category: 'bybit-ws'});
 
@@ -155,8 +187,8 @@ export class WebsocketClient extends EventEmitter {
     return  '';
   }
 
-  _reconnect(timeout) {
-    this._teardown();
+  private reconnectWithDelay(connectionDelay: number) {
+    this.teardown();
     if (this.readyState !== READY_STATE_CONNECTING) {
       this.readyState = READY_STATE_RECONNECTING;
     }
@@ -164,28 +196,28 @@ export class WebsocketClient extends EventEmitter {
     setTimeout(() => {
       this.logger.info('Reconnecting to server', { category: 'bybit-ws' });
 
-      this._connect();
-    }, timeout);
+      this.connect();
+    }, connectionDelay);
   }
 
-  _ping() {
+  private ping() {
     clearTimeout(this.pongTimeout!);
     delete this.pongTimeout;
 
     this.logger.silly('Sending ping', { category: 'bybit-ws' });
     this.ws.send(JSON.stringify({op: 'ping'}));
 
-    
+
     this.pongTimeout = <any>setTimeout(() => {
       this.logger.info('Pong timeout', { category: 'bybit-ws' });
-      this._teardown();
+      this.teardown();
       // this.ws.terminate();
       // TODO: does this work?
       this.ws.close();
     }, this.options.pongTimeout);
   }
 
-  _teardown() {
+  private teardown() {
     if (this.pingInterval) clearInterval(this.pingInterval);
     if (this.pongTimeout) clearTimeout(this.pongTimeout);
 
@@ -193,7 +225,31 @@ export class WebsocketClient extends EventEmitter {
     this.pingInterval = undefined;
   }
 
-  _wsOpenHandler() {
+  /**
+   * Send WS message to subscribe to topics.
+   */
+  private requestSubscribeTopics(topics: string[]) {
+    const msgStr = JSON.stringify({
+      op: 'subscribe',
+      'args': topics
+    });
+
+    this.ws.send(msgStr);
+  }
+
+  /**
+   * Send WS message to unsubscribe from topics.
+   */
+  private requestUnsubscribeTopics(topics: string[]) {
+    const msgStr = JSON.stringify({
+      op: 'unsubscribe',
+      'args': topics
+    });
+
+    this.ws.send(msgStr);
+  }
+
+  private onWsOpen() {
     if (this.readyState === READY_STATE_CONNECTING) {
       this.logger.info('Websocket connected', { category: 'bybit-ws', livenet: this.options.livenet, linear: this.options.linear });
       this.emit('open');
@@ -204,32 +260,34 @@ export class WebsocketClient extends EventEmitter {
 
     this.readyState = READY_STATE_CONNECTED;
 
-    this._subscribe([...this._subscriptions]);
-    this.pingInterval = <any>setInterval(this._ping.bind(this), this.options.pingInterval);
+    this.requestSubscribeTopics([...this.subcribedTopics]);
+    this.pingInterval = <any>setInterval(this.ping.bind(this), this.options.pingInterval);
   }
 
-  _wsMessageHandler(message) {
+  private onWsMessage(message) {
     const msg = JSON.parse(message && message.data || message);
 
     if ('success' in msg) {
-      this._handleResponse(msg);
+      this.onWsMessageResponse(msg);
     } else if (msg.topic) {
-      this._handleUpdate(msg);
+      this.onWsMessageUpdate(msg);
     } else {
       this.logger.warning('Got unhandled ws message', msg);
     }
   }
 
-  _wsOnErrorHandler(err) {
+  private onWsError(err) {
     this.logger.error('Websocket error', {category: 'bybit-ws', err});
-    if (this.readyState === READY_STATE_CONNECTED) this.emit('error', err);
+    if (this.readyState === READY_STATE_CONNECTED) {
+      this.emit('error', err);
+    }
   }
 
-  _wsCloseHandler() {
+  private onWsClose() {
     this.logger.info('Websocket connection closed', {category: 'bybit-ws'});
 
     if (this.readyState !== READY_STATE_CLOSING) {
-      this._reconnect(this.options.reconnectTimeout);
+      this.reconnectWithDelay(this.options.reconnectTimeout!);
       this.emit('reconnect');
     } else {
       this.readyState = READY_STATE_INITIAL;
@@ -237,7 +295,7 @@ export class WebsocketClient extends EventEmitter {
     }
   }
 
-  _handleResponse(response) {
+  private onWsMessageResponse(response) {
     if (
       response.request &&
       response.request.op === 'ping' &&
@@ -251,25 +309,7 @@ export class WebsocketClient extends EventEmitter {
     }
   }
 
-  _handleUpdate(message) {
+  private onWsMessageUpdate(message) {
     this.emit('update', message);
-  }
-
-  _subscribe(topics) {
-    const msgStr = JSON.stringify({
-      op: 'subscribe',
-      'args': topics
-    });
-
-    this.ws.send(msgStr);
-  }
-
-  _unsubscribe(topics) {
-    const msgStr = JSON.stringify({
-      op: 'unsubscribe',
-      'args': topics
-    });
-
-    this.ws.send(msgStr);
   }
 };

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -67,7 +67,7 @@ export class WebsocketClient extends EventEmitter {
     };
 
 
-    if (this.options.linear) {
+    if (!this.options.linear) {
       this.client = new InverseClient(undefined, undefined, this.options.livenet, this.options.restOptions, this.options.requestOptions);
     }else{
       this.client = new LinearClient(undefined, undefined, this.options.livenet, this.options.restOptions, this.options.requestOptions);

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -276,7 +276,7 @@ export class WebsocketClient extends EventEmitter {
   private clearPongTimer(wsKey: string) {
     const wsState = this.wsStore.get(wsKey);
     if (wsState?.activePongTimer) {
-      clearInterval(wsState.activePongTimer);
+      clearTimeout(wsState.activePongTimer);
       wsState.activePongTimer = undefined;
     }
   }

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -67,16 +67,15 @@ export class WebsocketClient extends EventEmitter {
     };
 
 
-    if (!this.options.linear) {
-      this.client = new InverseClient(undefined, undefined, this.options.livenet, this.options.restOptions, this.options.requestOptions);
-    }else{
+    if (this.options.linear === true) {
       this.client = new LinearClient(undefined, undefined, this.options.livenet, this.options.restOptions, this.options.requestOptions);
+    }else{
+      this.client = new InverseClient(undefined, undefined, this.options.livenet, this.options.restOptions, this.options.requestOptions);
     }
     
     this._subscriptions = new Set();
     this._connect();
   }
-
 
   subscribe(topics) {
     if (!Array.isArray(topics)) topics = [topics];
@@ -196,7 +195,7 @@ export class WebsocketClient extends EventEmitter {
 
   _wsOpenHandler() {
     if (this.readyState === READY_STATE_CONNECTING) {
-      this.logger.info('Websocket connected', { category: 'bybit-ws', livenet: this.options.livenet });
+      this.logger.info('Websocket connected', { category: 'bybit-ws', livenet: this.options.livenet, linear: this.options.linear });
       this.emit('open');
     } else if (this.readyState === READY_STATE_RECONNECTING) {
       this.logger.info('Websocket reconnected', { category: 'bybit-ws', livenet: this.options.livenet });

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -76,13 +76,9 @@ const getLinearWsKeyForTopic = (topic: string) => {
 }
 
 export declare interface WebsocketClient {
-  on(event: 'open', listener: ({ wsKey: string, event: any }) => void): this;
-  on(event: 'reconnected', listener: ({ wsKey: string, event: any }) => void): this;
-  on(event: 'reconnect', listener: () => void): this;
-  on(event: 'close', listener: () => void): this;
-  on(event: 'response', listener: (response: any) => void): this;
-  on(event: 'update', listener: (response: any) => void): this;
-  on(event: 'error', listener: (response: any) => void): this;
+  on(event: 'open' | 'reconnected', listener: ({ wsKey: string, event: any }) => void): this;
+  on(event: 'response' | 'update' | 'error', listener: (response: any) => void): this;
+  on(event: 'reconnect' | 'close', listener: () => void): this;
 }
 
 export class WebsocketClient extends EventEmitter {

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -169,9 +169,9 @@ export class WebsocketClient extends EventEmitter {
   /**
    * Request connection of all dependent websockets, instead of waiting for automatic connection by library
    */
-  public connectAll(): Promise<WebSocket> | Promise<WebSocket>[] | undefined {
+  public connectAll(): Promise<WebSocket>[] | undefined {
     if (this.isInverse()) {
-      return this.connect(wsKeyInverse);
+      return [this.connect(wsKeyInverse)];
     }
 
     if (this.options.linear === true) {

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -1,6 +1,5 @@
 import { EventEmitter } from 'events';
-
-import { RestClient } from './rest-client';
+import { InverseClient } from './inverse-client';
 import { DefaultLogger } from './logger';
 import { signMessage, serializeParams } from './util/requestUtils';
 // import WebSocket from 'ws';
@@ -37,7 +36,7 @@ export class WebsocketClient extends EventEmitter {
   private readyState: number;
   private pingInterval?: number | undefined;
   private pongTimeout?: number | undefined;
-  private client: RestClient;
+  private client: InverseClient;
   private _subscriptions: Set<unknown>;
   private ws: WebSocket;
   private options: WebsocketClientOptions;
@@ -59,7 +58,7 @@ export class WebsocketClient extends EventEmitter {
       ...options
     };
 
-    this.client = new RestClient(undefined, undefined, this.options.livenet, this.options.restOptions, this.options.requestOptions);
+    this.client = new InverseClient(undefined, undefined, this.options.livenet, this.options.restOptions, this.options.requestOptions);
     this._subscriptions = new Set();
 
     this._connect();
@@ -161,7 +160,8 @@ export class WebsocketClient extends EventEmitter {
     this.logger.silly('Sending ping', { category: 'bybit-ws' });
     this.ws.send(JSON.stringify({op: 'ping'}));
 
-    this.pongTimeout = setTimeout(() => {
+    
+    this.pongTimeout = <any>setTimeout(() => {
       this.logger.info('Pong timeout', { category: 'bybit-ws' });
       this._teardown();
       // this.ws.terminate();
@@ -190,7 +190,7 @@ export class WebsocketClient extends EventEmitter {
     this.readyState = READY_STATE_CONNECTED;
 
     this._subscribe([...this._subscriptions]);
-    this.pingInterval = setInterval(this._ping.bind(this), this.options.pingInterval);
+    this.pingInterval = <any>setInterval(this._ping.bind(this), this.options.pingInterval);
   }
 
   _wsMessageHandler(message) {


### PR DESCRIPTION
# Changelog
## Summary
- **Introducing All Linear Endpoints (USDT Pairs) to the project for both rest clients and websocket client.** Initiated through a seperate client (LinearClient) and stored in linear-client.ts. Most endpoints are the same as inverse, however some have different paramaters & results and some are linear specific endpoints.
  - Market Data Endpoints Added.
  - Account Data Endpoints Added.
  - Other Endpoints are contained within shared-endpoints.ts
- Introduce Shared Endpoints that are used by both Linear and Inverse Client (Through extend to sharedendpoints.ts).
- Transferred shared endpoints from inverse-client.ts to shared-endpoints.ts
- Other Misc Changes (e.g Commenting, small functions).
- Websocket Clients for Linear and shared endpoints added. Not a breaking change. Parameter "linear" can passed into websocket client if you want to use linear, however it defaults to inverse client.
- Refactored websocket state into flexible wsStore. All websocket-specific state is now stored here.
- Existing inverse websocket functionality is unchanged.

## Breaking Changes
- **RestClient** renamed to InverseClient. Only import needs rename as existing functionality is unchanged.
  - rest-client.ts renamed to inverse-client.ts
- Depreciations of old endpoints
  - A number of endpoints were marked deprecated by bybit with a deadline for December 2020. 
  - These have now been removed. 
- **Websocket connection on init**
  - **Previous behaviour**: websocket is automatically connected when websocket-client() instance is made.
  - **New behaviour**: websocket is automatically connected when a topic is subscribed to.
  - If the previous behaviour is necessary, earlier connections can be forced using the websocketClient.connectAll() method.

## Deprecations
These are a consequence of module improvements (mainly open-api calls, to v2):
- getActiveOrder() deprecated. Use getActiveOrderList() instead.
  - Same params & response.
- replaceActiveOrderOld() deprecated. Use replaceActiveOrder() instead.
  - Same params & response.
- placeConditionalOrderOld() deprecated. Use placeConditionalOrder() instead.
  - Same params & response.
- getConditionalOrderOld() deprecated. Use getConditionalOrder() instead.
  - Same params & response.
- cancelConditionalOrderOld() deprecated. Use cancelConditionalOrder() instead.
  - Same params & response.
- replaceConditionalOrderOld() deprecated. Use replaceConditionalOrder() instead.
  - Same params & response.
- replaceConditionalOrderOld() deprecated. Use replaceConditionalOrder() instead.
  - Same params & response.

## Endpoint Updates
- setTradingStop() updated from open-api to v2.
- getLastFundingRate() updated from open-api to v2.
- getMyLastFundingFee() updated from open-api to v2.
- getPredictedFunding() updated from open-api to v2.
- getApiKeyInfo() updated from open-api to v2.

## Testing locally
```
// go to anywhere you want to save a copy of the repo locally, ideally outside your current project, and clone it
git clone git@github.com:peepopoggers/bybit-api.git

// build it
cd bybit-api
npm install
npm run tsc

// link it
npm link

// cd into your project
cd pathtoyourproject

// link it to your local bybit module
npm link bybit-api
```

## TODO list
The following should work as before, except for any breaking changes documented above:
- [x] Inverse REST API, implementation, function names and params.
- [x] Inverse REST working as expected in **testnet**.
- [x] Inverse REST working as expected in **mainnet**.
- [x] Inverse WebSockets, implementation and usage.
- [x] Inverse WebSockets working as expected in **testnet**.
- [x] Inverse WebSockets working as expected in **mainnet**.

The following should be fully functional:
- [x] Linear REST API. Implementation should be similar to Inverse, except for minimal params.
- [x] Linear REST working as expected in **testnet**.
- [x] Linear REST working as expected in **mainnet**.
- [x] Inverse WebSockets, Implementation should be similar to Inverse, except for minimal params.
- [x] Inverse WebSockets working as expected in **testnet**.
- [x] Inverse WebSockets working as expected in **mainnet**.

Final checks:
- [x] Validate all of inverse endpoints for breaking changes. Any changes in behaviour should be documented.
- [x] Validate all of inverse endpoints for breaking changes. Any changes in behaviour should be documented.
- [x] Validate all of inverse endpoints for validity (params, endpoints, method order matches bybit documentation).
- [x] Validate all of linear endpoints for validity (params, endpoints, method order matches bybit documentation).
- [x] Readme has been updated based on new usage for inverse and linear, REST & WS.
- Adding documentation for linear endpoints, and depreciating old endpoints from docs.
- Updating documentation for new naming scheme and linear endpoints.