### PR TITLE
change when you initialize the requestwrapper to pass along the restI…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Node.js connector for Bybit's Inverse & Linear REST APIs and WebSockets",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -26,7 +26,7 @@ export class InverseClient extends SharedEndpoints {
     this.requestWrapper = new RequestWrapper(
       key,
       secret,
-      getRestBaseUrl(useLivenet),
+      getRestBaseUrl(useLivenet, restInverseOptions),
       restInverseOptions,
       requestOptions
     );

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -26,7 +26,7 @@ export class LinearClient extends SharedEndpoints {
     this.requestWrapper = new RequestWrapper(
       key,
       secret,
-      getRestBaseUrl(useLivenet),
+      getRestBaseUrl(useLivenet, restInverseOptions),
       restInverseOptions,
       requestOptions
     );


### PR DESCRIPTION
change when you initialize the requestwrapper to pass along the restInverseOptions to getBaseUrl currently the ability to pass your own baseUrl is not working.

I don't know Typescript but I'm assuming this is the correct fix