### PR TITLE
Add support for inverse futures endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ There are three REST API modules as there are some differences in each contract 
 2. `InverseFuturesClient` for inverse futures
 3. `LinearClient` for linear perpetual
 
-## REST Inverse
+### REST Inverse
 <details><summary>To use the inverse REST APIs, import the `InverseClient` Click here to expand and see full sample:</summary>
 
 ```javascript
@@ -103,7 +103,7 @@ client.getOrderBook({ symbol: 'BTCUSD' })
 
 See [inverse-client.ts](./src/inverse-client.ts) for further information.
 
-## REST Inverse Futures
+### REST Inverse Futures
 <details><summary>To use the inverse futures REST APIs, import the `InverseFuturesClient`. Click here to expand and see full sample:</summary>
 
 ```javascript
@@ -147,7 +147,7 @@ See [inverse-futures-client.ts](./src/inverse-futures-client.ts) for further inf
 
 **Note**: as of 6th March 2021 this is currently only for testnet. See the [Bybit API documentation](https://bybit-exchange.github.io/docs/inverse_futures/#t-introduction) for official updates.
 
-## REST Linear
+### REST Linear
 <details><summary>To use the Linear (USDT) REST APIs, import the `LinearClient`. Click here to expand and see full sample:</summary>
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -39,9 +39,19 @@ Build a bundle using webpack:
 
 The bundle can be found in `dist/`. Altough usage should be largely consistent, smaller differences will exist. Documentation is still TODO.
 
-### Inverse Contracts
-Since inverse and linear (USDT) contracts don't use the exact same APIs, the REST abstractions are split into two modules. To use the inverse REST APIs, import the `InverseClient`:
+### REST API Clients
 
+There are three REST API modules as there are some differences in each contract type.
+1. `InverseClient` for inverse perpetual
+2. `InverseFuturesClient` for inverse futures
+3. `LinearClient` for linear perpetual
+
+#### Inverse Contracts
+
+To use the inverse REST APIs, import the `InverseClient`:
+
+<details><summary>Click here to expand and see full sample:</summary>
+<p>
 ```javascript
 const { InverseClient } = require('bybit-api');
 
@@ -97,35 +107,62 @@ client.getOrderBook({ symbol: 'BTCUSD' })
     console.error("getOrderBook inverse error: ", err);
   });
 ```
+</p></details>
 
-See inverse [inverse-client.ts](./src/inverse-client.ts) for further information.
+See [inverse-client.ts](./src/inverse-client.ts) for further information.
+
+#### Inverse Futures Contracts
+**Note**: as of 6th March 2021 this is currently only for testnet. See the [Bybit API documentation](https://bybit-exchange.github.io/docs/inverse_futures/#t-introduction) for official updates.
+
+To use the inverse futures REST APIs, import the `InverseFuturesClient`:
+
+<details><summary>Click here to expand and see full sample:</summary>
+<p>
+```javascript
+const { InverseFuturesClient } = require('bybit-api');
+
+const API_KEY = 'xxx';
+const PRIVATE_KEY = 'yyy';
+const useLivenet = false;
+
+const client = new InverseFuturesClient(
+  API_KEY,
+  PRIVATE_KEY,
+
+  // optional, uses testnet by default. Set to 'true' to use livenet.
+  useLivenet,
+
+  // restClientOptions,
+  // requestLibraryOptions
+);
+
+client.getApiKeyInfo()
+  .then(result => {
+    console.log("apiKey result: ", result);
+  })
+  .catch(err => {
+    console.error("apiKey error: ", err);
+  });
+
+client.getOrderBook({ symbol: 'BTCUSDH21' })
+  .then(result => {
+    console.log("getOrderBook inverse futures result: ", result);
+  })
+  .catch(err => {
+    console.error("getOrderBook inverse futures error: ", err);
+  });
+```
+</p></details>
+
+See [inverse-futures-client.ts](./src/inverse-futures-client.ts) for further information.
 
 ### Linear Contracts
 To use the Linear (USDT) REST APIs, import the `LinearClient`:
 
+<details><summary>Click here to expand and see full sample:</summary>
+<p>
 ```javascript
 const { LinearClient } = require('bybit-api');
-
-const restClientOptions = {
-  // override the max size of the request window (in ms)
-  recv_window?: number;
-
-  // how often to sync time drift with bybit servers
-  sync_interval_ms?: number | string;
-
-  // Default: false. Disable above sync mechanism if true.
-  disable_time_sync?: boolean;
-
-  // Default: false. If true, we'll throw errors if any params are undefined
-  strict_param_validation?: boolean;
-
-  // Optionally override API protocol + domain
-  // e.g 'https://api.bytick.com'
-  baseUrl?: string;
-
-  // Default: true. whether to try and post-process request exceptions.
-  parse_exceptions?: boolean;
-};
 
 const API_KEY = 'xxx';
 const PRIVATE_KEY = 'yyy';
@@ -158,6 +195,7 @@ client.getOrderBook({ symbol: 'BTCUSDT' })
     console.error("getOrderBook linear error: ", err);
   });
 ```
+</p></details>
 
 ### WebSockets
 
@@ -167,6 +205,8 @@ Note: to use the linear websockets, pass "linear: true" in the constructor optio
 
 To connect to both linear and inverse websockets, make two instances of the WebsocketClient:
 
+<details><summary>Click here to expand and see full sample:</summary>
+<p>
 ```javascript
 const { WebsocketClient } = require('bybit-api');
 
@@ -240,11 +280,15 @@ ws.on('error', err => {
   console.error('ERR', err);
 });
 ```
+</p></details>
+
 See [websocket-client.ts](./src/websocket-client.ts) for further information.
 
 ### Customise Logging
 Pass a custom logger which supports the log methods `silly`, `debug`, `notice`, `info`, `warning` and `error`, or override methods from the default logger as desired:
 
+<details><summary>Click here to expand and see full sample:</summary>
+<p>
 ```js
 const { WebsocketClient, DefaultLogger } = require('bybit-api');
 
@@ -256,6 +300,7 @@ const ws = new WebsocketClient(
   DefaultLogger
 );
 ```
+</p></details>
 
 ## Contributions & Thanks
 ### Donations

--- a/README.md
+++ b/README.md
@@ -269,7 +269,9 @@ See [websocket-client.ts](./src/websocket-client.ts) for further information.
 Note: for linear websockets, pass `linear: true` in the constructor options when instancing the `WebsocketClient`. To connect to both linear and inverse websockets, make two instances of the WebsocketClient.
 
 ### Customise Logging
-<details><summary>Pass a custom logger which supports the log methods `silly`, `debug`, `notice`, `info`, `warning` and `error`, or override methods from the default logger as desired. Click here to expand and see full sample:</summary>
+Pass a custom logger which supports the log methods `silly`, `debug`, `notice`, `info`, `warning` and `error`, or override methods from the default logger as desired.
+
+<details><summary>Click here to expand and see full sample:</summary>
 
 ```javascript
 const { WebsocketClient, DefaultLogger } = require('bybit-api');

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ There are three REST API modules as there are some differences in each contract 
 To use the inverse REST APIs, import the `InverseClient`:
 
 <details><summary>Click here to expand and see full sample:</summary>
+
 ```javascript
 const { InverseClient } = require('bybit-api');
 
@@ -106,6 +107,7 @@ client.getOrderBook({ symbol: 'BTCUSD' })
     console.error("getOrderBook inverse error: ", err);
   });
 ```
+
 </details>
 
 See [inverse-client.ts](./src/inverse-client.ts) for further information.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Node.js connector for the Bybit APIs and WebSockets, with TypeScript & browser s
 ## Documentation
 Most methods accept JS objects. These can be populated using parameters specified by Bybit's API documentation.
 - [Bybit API Inverse Documentation](https://bybit-exchange.github.io/docs/inverse/#t-introduction).
+- [Bybit API Inverse Futures Documentation](https://bybit-exchange.github.io/docs/inverse_futures/#t-introduction).
 - [Bybit API Linear Documentation](https://bybit-exchange.github.io/docs/linear/#t-introduction)
 
 ## Structure

--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ This project uses typescript. Resources are stored in 3 key structures:
 - [lib](./lib) - the javascript version of the project (compiled from typescript). This should not be edited directly, as it will be overwritten with each release.
 - [dist](./dist) - the packed bundle of the project for use in browser environments.
 
-## Usage
+---
+
+# Usage
 Create API credentials at Bybit
 - [Livenet](https://bybit.com/app/user/api-management?affiliate_id=9410&language=en-US&group_id=0&group_type=1)
 - [Testnet](https://testnet.bybit.com/app/user/api-management)
 
-### REST API Clients
+## REST API Clients
 
 There are three REST API modules as there are some differences in each contract type.
 1. `InverseClient` for inverse perpetual
@@ -268,7 +270,7 @@ See [websocket-client.ts](./src/websocket-client.ts) for further information.
 
 Note: for linear websockets, pass `linear: true` in the constructor options when instancing the `WebsocketClient`. To connect to both linear and inverse websockets, make two instances of the WebsocketClient.
 
-### Customise Logging
+## Customise Logging
 Pass a custom logger which supports the log methods `silly`, `debug`, `notice`, `info`, `warning` and `error`, or override methods from the default logger as desired.
 
 <details><summary>Click here to expand and see full sample:</summary>
@@ -287,7 +289,7 @@ const ws = new WebsocketClient(
 
 </details>
 
-### Browser Usage
+## Browser Usage
 Build a bundle using webpack:
 - `npm install`
 - `npm build`

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ There are three REST API modules as there are some differences in each contract 
 3. `LinearClient` for linear perpetual
 
 ### REST Inverse
-<details><summary>To use the inverse REST APIs, import the `InverseClient` Click here to expand and see full sample:</summary>
+<details><summary>To use the inverse REST APIs, import the `InverseClient`. Click here to expand and see full sample:</summary>
 
 ```javascript
 const { InverseClient } = require('bybit-api');

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Node.js connector for the Bybit APIs and WebSockets, with TypeScript & browser s
 ## Issues & Discussion
 - Issues? Check the [issues tab](https://github.com/tiagosiebler/bybit-api/issues).
 - Discuss & collaborate with other node devs? Join our [Node.js Algo Traders](https://t.me/nodetraders) engineering community on telegram.
-- `'bybit-api' has no exported member 'RestClient'`: use `InverseClient` instead of `RestClient`
 
 ## Documentation
 Most methods accept JS objects. These can be populated using parameters specified by Bybit's API documentation.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ There are three REST API modules as there are some differences in each contract 
 2. `InverseFuturesClient` for inverse futures
 3. `LinearClient` for linear perpetual
 
-## Inverse Contracts
+## REST Inverse
 <details><summary>To use the inverse REST APIs, import the `InverseClient` Click here to expand and see full sample:</summary>
 
 ```javascript
@@ -101,7 +101,7 @@ client.getOrderBook({ symbol: 'BTCUSD' })
 
 See [inverse-client.ts](./src/inverse-client.ts) for further information.
 
-## Inverse Futures Contracts
+## REST Inverse Futures
 <details><summary>To use the inverse futures REST APIs, import the `InverseFuturesClient`. Click here to expand and see full sample:</summary>
 
 ```javascript
@@ -145,7 +145,7 @@ See [inverse-futures-client.ts](./src/inverse-futures-client.ts) for further inf
 
 **Note**: as of 6th March 2021 this is currently only for testnet. See the [Bybit API documentation](https://bybit-exchange.github.io/docs/inverse_futures/#t-introduction) for official updates.
 
-## Linear Contracts
+## REST Linear
 <details><summary>To use the Linear (USDT) REST APIs, import the `LinearClient`. Click here to expand and see full sample:</summary>
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ client.getOrderBook({ symbol: 'BTCUSDH21' })
 
 See [inverse-futures-client.ts](./src/inverse-futures-client.ts) for further information.
 
-### Linear Contracts
+## Linear Contracts
 <details><summary>To use the Linear (USDT) REST APIs, import the `LinearClient`. Click here to expand and see full sample:</summary>
 
 ```javascript
@@ -193,7 +193,7 @@ client.getOrderBook({ symbol: 'BTCUSDT' })
 
 </details>
 
-### WebSockets
+## WebSockets
 
 Inverse & linear WebSockets can be used via a shared `WebsocketClient`.
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ See [inverse-client.ts](./src/inverse-client.ts) for further information.
 To use the inverse futures REST APIs, import the `InverseFuturesClient`:
 
 <details><summary>Click here to expand and see full sample:</summary>
-<p>
+
 ```javascript
 const { InverseFuturesClient } = require('bybit-api');
 
@@ -153,7 +153,8 @@ client.getOrderBook({ symbol: 'BTCUSDH21' })
     console.error("getOrderBook inverse futures error: ", err);
   });
 ```
-</p></details>
+
+</details>
 
 See [inverse-futures-client.ts](./src/inverse-futures-client.ts) for further information.
 
@@ -161,7 +162,7 @@ See [inverse-futures-client.ts](./src/inverse-futures-client.ts) for further inf
 To use the Linear (USDT) REST APIs, import the `LinearClient`:
 
 <details><summary>Click here to expand and see full sample:</summary>
-<p>
+
 ```javascript
 const { LinearClient } = require('bybit-api');
 
@@ -196,7 +197,8 @@ client.getOrderBook({ symbol: 'BTCUSDT' })
     console.error("getOrderBook linear error: ", err);
   });
 ```
-</p></details>
+
+</details>
 
 ### WebSockets
 
@@ -207,7 +209,7 @@ Note: to use the linear websockets, pass "linear: true" in the constructor optio
 To connect to both linear and inverse websockets, make two instances of the WebsocketClient:
 
 <details><summary>Click here to expand and see full sample:</summary>
-<p>
+
 ```javascript
 const { WebsocketClient } = require('bybit-api');
 
@@ -281,7 +283,8 @@ ws.on('error', err => {
   console.error('ERR', err);
 });
 ```
-</p></details>
+
+</details>
 
 See [websocket-client.ts](./src/websocket-client.ts) for further information.
 
@@ -289,8 +292,8 @@ See [websocket-client.ts](./src/websocket-client.ts) for further information.
 Pass a custom logger which supports the log methods `silly`, `debug`, `notice`, `info`, `warning` and `error`, or override methods from the default logger as desired:
 
 <details><summary>Click here to expand and see full sample:</summary>
-<p>
-```js
+
+```javascript
 const { WebsocketClient, DefaultLogger } = require('bybit-api');
 
 // Disable all logging on the silly level
@@ -301,7 +304,8 @@ const ws = new WebsocketClient(
   DefaultLogger
 );
 ```
-</p></details>
+
+</details>
 
 ## Contributions & Thanks
 ### Donations

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ There are three REST API modules as there are some differences in each contract 
 To use the inverse REST APIs, import the `InverseClient`:
 
 <details><summary>Click here to expand and see full sample:</summary>
-<p>
 ```javascript
 const { InverseClient } = require('bybit-api');
 
@@ -107,7 +106,7 @@ client.getOrderBook({ symbol: 'BTCUSD' })
     console.error("getOrderBook inverse error: ", err);
   });
 ```
-</p></details>
+</details>
 
 See [inverse-client.ts](./src/inverse-client.ts) for further information.
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,6 @@ client.getOrderBook({ symbol: 'BTCUSD' })
 See [inverse-client.ts](./src/inverse-client.ts) for further information.
 
 ## Inverse Futures Contracts
-**Note**: as of 6th March 2021 this is currently only for testnet. See the [Bybit API documentation](https://bybit-exchange.github.io/docs/inverse_futures/#t-introduction) for official updates.
-
 <details><summary>To use the inverse futures REST APIs, import the `InverseFuturesClient`. Click here to expand and see full sample:</summary>
 
 ```javascript
@@ -152,6 +150,8 @@ client.getOrderBook({ symbol: 'BTCUSDH21' })
 </details>
 
 See [inverse-futures-client.ts](./src/inverse-futures-client.ts) for further information.
+
+**Note**: as of 6th March 2021 this is currently only for testnet. See the [Bybit API documentation](https://bybit-exchange.github.io/docs/inverse_futures/#t-introduction) for official updates.
 
 ## Linear Contracts
 <details><summary>To use the Linear (USDT) REST APIs, import the `LinearClient`. Click here to expand and see full sample:</summary>
@@ -194,12 +194,7 @@ client.getOrderBook({ symbol: 'BTCUSDT' })
 </details>
 
 ## WebSockets
-
-Inverse & linear WebSockets can be used via a shared `WebsocketClient`.
-
-Note: for linear websockets, pass "linear: true" in the constructor options when instancing the `WebsocketClient`.
-
-<details><summary>To connect to both linear and inverse websockets, make two instances of the WebsocketClient. Click here to expand and see full sample:</summary>
+<details><summary>Inverse & linear WebSockets can be used via a shared `WebsocketClient`. Click here to expand and see full sample:</summary>
 
 ```javascript
 const { WebsocketClient } = require('bybit-api');
@@ -277,12 +272,11 @@ ws.on('error', err => {
 
 </details>
 
+Note: for linear websockets, pass "linear: true" in the constructor options when instancing the `WebsocketClient`. To connect to both linear and inverse websockets, make two instances of the WebsocketClient.
 See [websocket-client.ts](./src/websocket-client.ts) for further information.
 
 ### Customise Logging
-Pass a custom logger which supports the log methods `silly`, `debug`, `notice`, `info`, `warning` and `error`, or override methods from the default logger as desired:
-
-<details><summary>Click here to expand and see full sample:</summary>
+<details><summary>Pass a custom logger which supports the log methods `silly`, `debug`, `notice`, `info`, `warning` and `error`, or override methods from the default logger as desired. Click here to expand and see full sample:</summary>
 
 ```javascript
 const { WebsocketClient, DefaultLogger } = require('bybit-api');

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [1]: https://www.npmjs.com/package/bybit-api
 
-A production-ready Node.js connector for the Bybit APIs and WebSockets, with TypeScript & browser support.
+Node.js connector for the Bybit APIs and WebSockets, with TypeScript & browser support.
 
 ## Installation
 `npm install --save bybit-api`

--- a/README.md
+++ b/README.md
@@ -46,11 +46,8 @@ There are three REST API modules as there are some differences in each contract 
 2. `InverseFuturesClient` for inverse futures
 3. `LinearClient` for linear perpetual
 
-#### Inverse Contracts
-
-To use the inverse REST APIs, import the `InverseClient`:
-
-<details><summary>Click here to expand and see full sample:</summary>
+## Inverse Contracts
+<details><summary>To use the inverse REST APIs, import the `InverseClient` Click here to expand and see full sample:</summary>
 
 ```javascript
 const { InverseClient } = require('bybit-api');
@@ -112,12 +109,10 @@ client.getOrderBook({ symbol: 'BTCUSD' })
 
 See [inverse-client.ts](./src/inverse-client.ts) for further information.
 
-#### Inverse Futures Contracts
+## Inverse Futures Contracts
 **Note**: as of 6th March 2021 this is currently only for testnet. See the [Bybit API documentation](https://bybit-exchange.github.io/docs/inverse_futures/#t-introduction) for official updates.
 
-To use the inverse futures REST APIs, import the `InverseFuturesClient`:
-
-<details><summary>Click here to expand and see full sample:</summary>
+<details><summary>To use the inverse futures REST APIs, import the `InverseFuturesClient`. Click here to expand and see full sample:</summary>
 
 ```javascript
 const { InverseFuturesClient } = require('bybit-api');
@@ -159,9 +154,7 @@ client.getOrderBook({ symbol: 'BTCUSDH21' })
 See [inverse-futures-client.ts](./src/inverse-futures-client.ts) for further information.
 
 ### Linear Contracts
-To use the Linear (USDT) REST APIs, import the `LinearClient`:
-
-<details><summary>Click here to expand and see full sample:</summary>
+<details><summary>To use the Linear (USDT) REST APIs, import the `LinearClient`. Click here to expand and see full sample:</summary>
 
 ```javascript
 const { LinearClient } = require('bybit-api');
@@ -204,11 +197,9 @@ client.getOrderBook({ symbol: 'BTCUSDT' })
 
 Inverse & linear WebSockets can be used via a shared `WebsocketClient`.
 
-Note: to use the linear websockets, pass "linear: true" in the constructor options when instancing the `WebsocketClient`.
+Note: for linear websockets, pass "linear: true" in the constructor options when instancing the `WebsocketClient`.
 
-To connect to both linear and inverse websockets, make two instances of the WebsocketClient:
-
-<details><summary>Click here to expand and see full sample:</summary>
+<details><summary>To connect to both linear and inverse websockets, make two instances of the WebsocketClient. Click here to expand and see full sample:</summary>
 
 ```javascript
 const { WebsocketClient } = require('bybit-api');

--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ See [websocket-client.ts](./src/websocket-client.ts) for further information.
 
 Note: for linear websockets, pass `linear: true` in the constructor options when instancing the `WebsocketClient`. To connect to both linear and inverse websockets, make two instances of the WebsocketClient.
 
+---
+
 ## Customise Logging
 Pass a custom logger which supports the log methods `silly`, `debug`, `notice`, `info`, `warning` and `error`, or override methods from the default logger as desired.
 
@@ -298,6 +300,8 @@ Build a bundle using webpack:
 The bundle can be found in `dist/`. Altough usage should be largely consistent, smaller differences will exist. Documentation is still TODO.
 
 However, note that browser usage will lead to CORS errors due Bybit. See [issue #79](#79) for more information & alternative suggestions.
+
+---
 
 ## Contributions & Thanks
 ### Donations

--- a/README.md
+++ b/README.md
@@ -31,14 +31,6 @@ Create API credentials at Bybit
 - [Livenet](https://bybit.com/app/user/api-management?affiliate_id=9410&language=en-US&group_id=0&group_type=1)
 - [Testnet](https://testnet.bybit.com/app/user/api-management)
 
-### Browser Usage
-Build a bundle using webpack:
-- `npm install`
-- `npm build`
-- `npm pack`
-
-The bundle can be found in `dist/`. Altough usage should be largely consistent, smaller differences will exist. Documentation is still TODO.
-
 ### REST API Clients
 
 There are three REST API modules as there are some differences in each contract type.
@@ -272,8 +264,9 @@ ws.on('error', err => {
 
 </details>
 
-Note: for linear websockets, pass "linear: true" in the constructor options when instancing the `WebsocketClient`. To connect to both linear and inverse websockets, make two instances of the WebsocketClient.
 See [websocket-client.ts](./src/websocket-client.ts) for further information.
+
+Note: for linear websockets, pass `linear: true` in the constructor options when instancing the `WebsocketClient`. To connect to both linear and inverse websockets, make two instances of the WebsocketClient.
 
 ### Customise Logging
 <details><summary>Pass a custom logger which supports the log methods `silly`, `debug`, `notice`, `info`, `warning` and `error`, or override methods from the default logger as desired. Click here to expand and see full sample:</summary>
@@ -291,6 +284,16 @@ const ws = new WebsocketClient(
 ```
 
 </details>
+
+### Browser Usage
+Build a bundle using webpack:
+- `npm install`
+- `npm build`
+- `npm pack`
+
+The bundle can be found in `dist/`. Altough usage should be largely consistent, smaller differences will exist. Documentation is still TODO.
+
+However, note that browser usage will lead to CORS errors due Bybit. See [issue #79](#79) for more information & alternative suggestions.
 
 ## Contributions & Thanks
 ### Donations

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Node.js connector for Bybit's Inverse & Linear REST APIs and WebSockets",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './inverse-client';
+export * from './inverse-futures-client';
 export * from './linear-client';
 export * from './websocket-client';
 export * from './logger';

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -18,7 +18,7 @@ export class InverseClient extends SharedEndpoints {
   constructor(
     key?: string | undefined,
     secret?: string | undefined,
-    useLivenet?: boolean,
+    useLivenet: boolean = false,
     restClientOptions: RestClientOptions = {},
     requestOptions: AxiosRequestConfig = {}
   ) {

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -282,6 +282,7 @@ export class InverseClient extends SharedEndpoints {
     symbol: string;
     take_profit?: number;
     stop_loss?: number;
+    trailing_stop?: number;
     tp_trigger_by?: string;
     sl_trigger_by?: string;
     new_trailing_active?: number;

--- a/src/inverse-futures-client.ts
+++ b/src/inverse-futures-client.ts
@@ -7,7 +7,7 @@ export class InverseFuturesClient extends SharedEndpoints {
   protected requestWrapper: RequestWrapper;
 
   /**
-   * @public Creates an instance of the inverse REST API client.
+   * @public Creates an instance of the inverse futures REST API client.
    *
    * @param {string} key - your API key
    * @param {string} secret - your API secret

--- a/src/inverse-futures-client.ts
+++ b/src/inverse-futures-client.ts
@@ -1,0 +1,354 @@
+import { AxiosRequestConfig } from 'axios';
+import { GenericAPIResponse, getRestBaseUrl, RestClientOptions } from './util/requestUtils';
+import RequestWrapper from './util/requestWrapper';
+import SharedEndpoints from './shared-endpoints';
+
+export class InverseFuturesClient extends SharedEndpoints {
+  protected requestWrapper: RequestWrapper;
+
+  /**
+   * @public Creates an instance of the inverse REST API client.
+   *
+   * @param {string} key - your API key
+   * @param {string} secret - your API secret
+   * @param {boolean} [useLivenet=false]
+   * @param {RestClientOptions} [restClientOptions={}] options to configure REST API connectivity
+   * @param {AxiosRequestConfig} [requestOptions={}] HTTP networking options for axios
+   */
+  constructor(
+    key?: string | undefined,
+    secret?: string | undefined,
+    useLivenet: boolean = false,
+    restClientOptions: RestClientOptions = {},
+    requestOptions: AxiosRequestConfig = {}
+  ) {
+    super()
+    this.requestWrapper = new RequestWrapper(
+      key,
+      secret,
+      getRestBaseUrl(useLivenet, restClientOptions),
+      restClientOptions,
+      requestOptions
+    );
+    return this;
+  }
+
+  /**
+   *
+   * Market Data Endpoints
+   *    Note: These are currently the same as the inverse client
+   */
+
+  getKline(params: {
+    symbol: string;
+    interval: string;
+    from: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/kline/list', params);
+  }
+
+  /**
+   * Public trading records
+   */
+  getTrades(params: {
+    symbol: string;
+    from?: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/trading-records', params);
+  }
+
+  getMarkPriceKline(params: {
+    symbol: string;
+    interval: string;
+    from: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/mark-price-kline', params);
+  }
+
+  getIndexPriceKline(params: {
+    symbol: string;
+    interval: string;
+    from: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/index-price-kline', params);
+  }
+
+  getPremiumIndexKline(params: {
+    symbol: string;
+    interval: string;
+    from: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/premium-index-kline', params);
+  }
+
+  /**
+   *
+   * Account Data Endpoints
+   *
+   */
+
+	/**
+   * Active orders
+   */
+
+  placeActiveOrder(orderRequest: {
+    side: string;
+    symbol: string;
+    order_type: string;
+    qty: number;
+    price?: number;
+    time_in_force: string;
+    take_profit?: number;
+    stop_loss?: number;
+    reduce_only?: boolean;
+    close_on_trigger?: boolean;
+    order_link_id?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('futures/private/order/create', orderRequest);
+  }
+
+  getActiveOrderList(params: {
+    symbol: string;
+    order_status?: string;
+    direction?: string;
+    limit?: number;
+    cursor?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('futures/private/order/list', params);
+  }
+
+  cancelActiveOrder(params: {
+    symbol: string;
+    order_id?: string;
+    order_link_id?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('futures/private/order/cancel', params);
+  }
+
+  cancelAllActiveOrders(params: {
+    symbol: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('futures/private/order/cancelAll', params);
+  }
+
+  replaceActiveOrder(params: {
+    order_id?: string;
+    order_link_id?: string;
+    symbol: string;
+    p_r_qty?: string;
+    p_r_price?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('futures/private/order/replace', params);
+  }
+
+  queryActiveOrder(params: {
+    order_id?: string;
+    order_link_id?: string;
+    symbol: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('futures/private/order', params);
+  }
+
+	/**
+   * Conditional orders
+   */
+
+  placeConditionalOrder(params: {
+    side: string;
+    symbol: string;
+    order_type: string;
+    qty: string;
+    price?: string;
+    base_price: string;
+    stop_px: string;
+    time_in_force: string;
+    trigger_by?: string;
+    close_on_trigger?: boolean;
+    order_link_id?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('futures/private/stop-order/create', params);
+  }
+
+  getConditionalOrder(params: {
+    symbol: string;
+    stop_order_status?: string;
+    direction?: string;
+    limit?: number;
+    cursor?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('futures/private/stop-order/list', params);
+  }
+
+  cancelConditionalOrder(params: {
+    symbol: string;
+    stop_order_id?: string;
+    order_link_id?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('futures/private/stop-order/cancel', params);
+  }
+
+  cancelAllConditionalOrders(params: {
+    symbol: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('futures/private/stop-order/cancelAll', params);
+  }
+
+  replaceConditionalOrder(params: {
+    stop_order_id?: string;
+    order_link_id?: string;
+    symbol: string;
+    p_r_qty?: number;
+    p_r_price?: string;
+    p_r_trigger_price?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('futures/private/stop-order/replace', params);
+  }
+
+  queryConditionalOrder(params: {
+    symbol: string;
+    stop_order_id?: string;
+    order_link_id?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('futures/private/stop-order', params);
+  }
+
+	/**
+   * Position
+   */
+
+
+  /**
+   * Get position list
+   */
+  getPosition(params?: {
+    symbol?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('futures/private/position/list', params);
+  }
+
+  changePositionMargin(params: {
+    symbol: string;
+    margin: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('futures/private/position/change-position-margin', params);
+  }
+
+  setTradingStop(params: {
+    symbol: string;
+    take_profit?: number;
+    stop_loss?: number;
+    trailing_stop?: number;
+    tp_trigger_by?: string;
+    sl_trigger_by?: string;
+    new_trailing_active?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('futures/private/position/trading-stop', params);
+  }
+
+  setUserLeverage(params: {
+    symbol: string;
+    buy_leverage: number;
+    sell_leverage: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('futures/private/position/leverage/save', params);
+  }
+
+  /**
+   * Position mode switch
+   */
+  setPositionMode(params: {
+    symbol: string;
+    mode: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('futures/private/position/switch-mode', params);
+  }
+
+  /**
+   * Cross/Isolated margin switch. Must set leverage value when switching.
+   */
+  setMarginType(params: {
+    symbol: string;
+    is_isolated: boolean;
+    buy_leverage: number;
+    sell_leverage: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('futures/private/position/switch-isolated', params);
+  }
+
+  getTradeRecords(params: {
+    order_id?: string;
+    symbol: string;
+    start_time?: number;
+    page?: number;
+    limit?: number;
+    order?: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('futures/private/execution/list', params);
+  }
+
+  getClosedPnl(params: {
+    symbol: string;
+    start_time?: number;
+    end_time?: number;
+    exec_type?: string;
+    page?: number;
+    limit?: number;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('futures/private/trade/closed-pnl/list', params);
+  }
+
+  /**
+   **** The following are all the same as the inverse client ****
+   */
+
+	/**
+   * Risk Limit
+   */
+  getRiskLimitList(): GenericAPIResponse {
+    return this.requestWrapper.get('open-api/wallet/risk-limit/list');
+  }
+
+  setRiskLimit(params: {
+    symbol: string;
+    risk_id: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.post('open-api/wallet/risk-limit', params);
+  }
+
+	/**
+   * Funding
+   */
+
+  getLastFundingRate(params: {
+    symbol: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/public/funding/prev-funding-rate', params);
+  }
+
+  getMyLastFundingFee(params: {
+    symbol: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/private/funding/prev-funding', params);
+  }
+
+  getPredictedFunding(params: {
+    symbol: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/private/funding/predicted-funding', params);
+  }
+
+	/**
+   * LCP Info
+   */
+
+  getLcpInfo(params: {
+    symbol: string;
+  }): GenericAPIResponse {
+    return this.requestWrapper.get('v2/private/account/lcp', params);
+  }
+};

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -18,7 +18,7 @@ export class LinearClient extends SharedEndpoints {
   constructor(
     key?: string | undefined,
     secret?: string | undefined,
-    useLivenet?: boolean,
+    useLivenet: boolean = false,
     restClientOptions: RestClientOptions = {},
     requestOptions: AxiosRequestConfig = {}
   ) {

--- a/src/shared-endpoints.ts
+++ b/src/shared-endpoints.ts
@@ -17,6 +17,9 @@ export default class SharedEndpoints {
     return this.requestWrapper.get('v2/public/orderBook/L2', params);
   }
 
+  /**
+   * Get latest information for symbol
+   */
   getTickers(params?: {
     symbol?: string;
   }): GenericAPIResponse {
@@ -27,6 +30,9 @@ export default class SharedEndpoints {
     return this.requestWrapper.get('v2/public/symbols');
   }
 
+  /**
+   * Get liquidated orders
+   */
   getLiquidations(params: {
     symbol: string;
     from?: number;

--- a/src/util/requestUtils.ts
+++ b/src/util/requestUtils.ts
@@ -42,13 +42,13 @@ export function serializeParams(params: object = {}, strict_validation = false):
     .join('&');
 };
 
-export function getRestBaseUrl(useLivenet?: boolean, restInverseOptions?: RestClientOptions) {
+export function getRestBaseUrl(useLivenet: boolean, restInverseOptions: RestClientOptions) {
   const baseUrlsInverse = {
     livenet: 'https://api.bybit.com',
     testnet: 'https://api-testnet.bybit.com'
   };
 
-  if (restInverseOptions?.baseUrl) {
+  if (restInverseOptions.baseUrl) {
     return restInverseOptions.baseUrl;
   }
 

--- a/src/util/requestWrapper.ts
+++ b/src/util/requestWrapper.ts
@@ -55,7 +55,6 @@ export default class RequestUtil {
     this.secret = secret;
   }
 
-  // TODO: type check that endpoint never starts with forward slash??
   get(endpoint: string, params?: any): GenericAPIResponse {
     return this._call('GET', endpoint, params);
   }


### PR DESCRIPTION
## Summary
- Introduce a new REST client: `InverseFuturesClient`. Resolves #82.
- Update & clean readme.
- Add missing inverse parameter.