### PR TITLE
add missing optional param for set leverage method

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ const API_KEY = 'xxx';
 const PRIVATE_KEY = 'yyy';
 const useLivenet = false;
 
-const client = new javascript(
+const client = new SpotClient(
   API_KEY,
   PRIVATE_KEY,
 

--- a/src/inverse-client.ts
+++ b/src/inverse-client.ts
@@ -294,6 +294,7 @@ export class InverseClient extends SharedEndpoints {
   setUserLeverage(params: {
     symbol: string;
     leverage: number;
+    leverage_only?: boolean;
   }): GenericAPIResponse {
     return this.requestWrapper.post('v2/private/position/leverage/save', params);
   }


### PR DESCRIPTION
Hello, @tiagosiebler 
An optional parameter `leverage_only` requires for the following circumstance.


> Use this parameter to set leverage while in cross margin mode.
If this field is set to false, when leverage is equal to 0 the position will use cross margin; when leverage is greater than 0 the position will use isolated margin.
If this field is set to true, you can set leverage in cross margin with leverage. leverage must be greater than 0.
Use the Cross/Isolated Margin Switch endpoint to switch cross/isolated without modifying the cross level of leverage.
