### PR TITLE
Private POST spot API calls & WebSocket topics

### DIFF
--- a/src/spot-client.ts
+++ b/src/spot-client.ts
@@ -66,7 +66,7 @@ export class SpotClient extends BaseRestClient {
   }
 
   getTrades(symbol: string, limit?: number) {
-    return this.get('/spot/v1/trades', {
+    return this.get('/spot/quote/v1/trades', {
       symbol,
       limit,
     });

--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -79,7 +79,7 @@ export default abstract class BaseRestClient {
   /**
    * @private Make a HTTP request to a specific endpoint. Private endpoints are automatically signed.
    */
-  private async _call(method: Method, endpoint: string, params?: any, isPublicApi?: boolean): GenericAPIResponse {    
+  private async _call(method: Method, endpoint: string, params?: any, isPublicApi?: boolean): GenericAPIResponse {
     if (!isPublicApi) {
       if (!this.key || !this.secret) {
         throw new Error('Private endpoints require api and private keys set');

--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -80,6 +80,11 @@ export default abstract class BaseRestClient {
    * @private Make a HTTP request to a specific endpoint. Private endpoints are automatically signed.
    */
   private async _call(method: Method, endpoint: string, params?: any, isPublicApi?: boolean): GenericAPIResponse {
+    if (params) {
+      // Filter undefined values
+      params = Object.entries(params).reduce((a, [k, v]) => (v === undefined ? a : (a[k]=v, a)), {});
+    }
+    
     if (!isPublicApi) {
       if (!this.key || !this.secret) {
         throw new Error('Private endpoints require api and private keys set');

--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -79,12 +79,7 @@ export default abstract class BaseRestClient {
   /**
    * @private Make a HTTP request to a specific endpoint. Private endpoints are automatically signed.
    */
-  private async _call(method: Method, endpoint: string, params?: any, isPublicApi?: boolean): GenericAPIResponse {
-    if (params) {
-      // Filter undefined values
-      params = Object.entries(params).reduce((a, [k, v]) => (v === undefined ? a : (a[k]=v, a)), {});
-    }
-    
+  private async _call(method: Method, endpoint: string, params?: any, isPublicApi?: boolean): GenericAPIResponse {    
     if (!isPublicApi) {
       if (!this.key || !this.secret) {
         throw new Error('Private endpoints require api and private keys set');

--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -99,7 +99,7 @@ export default abstract class BaseRestClient {
       json: true
     };
 
-    if (method === 'GET') {
+    if (method === 'GET' || endpoint.includes('spot')) {
       options.params = params;
     } else {
       options.data = params;

--- a/src/util/requestUtils.ts
+++ b/src/util/requestUtils.ts
@@ -61,7 +61,7 @@ export function isPublicEndpoint (endpoint: string): boolean {
 }
 
 export function isWsPong(response: any) {
-  if (response.pong) {
+  if (response.pong || response.ping) {
     return true;
   }
   return (

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -557,10 +557,16 @@ export class WebsocketClient extends EventEmitter {
   private onWsMessage(event, wsKey: WsKey) {
     try {
       const msg = JSON.parse(event && event.data || event);
-      if ('success' in msg || msg?.pong) {
+      if ('success' in msg || msg?.pong || msg?.auth === 'success' || msg?.ping) {
         this.onWsMessageResponse(msg, wsKey);
       } else if (msg.topic) {
         this.onWsMessageUpdate(msg);
+      } else if (Array.isArray(msg)) {
+        for (const item of msg) {
+          if (['outboundAccountInfo', 'executionReport', 'ticketInfo'].includes(item.e)) {
+            this.onWsMessageUpdate(msg);
+          }
+        }
       } else {
         this.logger.warning('Got unhandled ws message', { ...loggerCategory, message: msg, event, wsKey});
       }

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -388,7 +388,7 @@ export class WebsocketClient extends EventEmitter {
   /**
    * Return params required to make authorized request
    */
-  private async getAuthParams(wsKey: WsKey): Promise<string> {
+  private async getAuthParams(wsKey: WsKey, authSpotPrivate=false): Promise<string> {
     const { key, secret } = this.options;
 
     if (key && secret && wsKey !== wsKeyLinearPublic && wsKey !== wsKeySpotPublic) {
@@ -398,7 +398,7 @@ export class WebsocketClient extends EventEmitter {
       const expires = Date.now() + timeOffset + 5000;
       const signature = await signMessage('GET/realtime' + expires, secret);
 
-      if (wsKey === wsKeySpotPrivate) {
+      if (authSpotPrivate) {
         return JSON.stringify({
           op: 'auth',
           args: [key, expires, signature]
@@ -544,7 +544,7 @@ export class WebsocketClient extends EventEmitter {
     }
 
     if (wsKey === 'spotPrivate') {
-      this.tryWsSend(wsKeySpotPrivate, await this.getAuthParams(wsKeySpotPrivate));
+      this.tryWsSend(wsKeySpotPrivate, await this.getAuthParams(wsKeySpotPrivate, true));
     }
 
     this.wsStore.get(wsKey, true)!.activePingTimer = setInterval(

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -549,8 +549,14 @@ export class WebsocketClient extends EventEmitter {
   private onWsMessage(event, wsKey: WsKey) {
     try {
       const msg = JSON.parse(event && event.data || event);
-      if ('success' in msg || msg?.pong || msg?.auth === 'success' || msg?.ping) {
+      if ('success' in msg || msg?.pong || msg?.ping) {
         this.onWsMessageResponse(msg, wsKey);
+      } else if (msg?.auth) {
+        if (msg?.auth === 'success') {
+          this.logger.info('Authenticated', { ...loggerCategory, wsKey });
+        } else {
+          this.logger.warning('Fail to authenticated', { ...loggerCategory, message: msg, event, wsKey});
+        }
       } else if (msg.topic) {
         this.onWsMessageUpdate(msg);
       } else if (Array.isArray(msg)) {

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -512,7 +512,7 @@ export class WebsocketClient extends EventEmitter {
     this.logger.silly(`Opening WS connection to URL: ${url}`, { ...loggerCategory, wsKey })
 
     const ws = new WebSocket(url);
-    ws.onopen = async event => await this.onWsOpen(event, wsKey);
+    ws.onopen = event => this.onWsOpen(event, wsKey);
     ws.onmessage = event => this.onWsMessage(event, wsKey);
     ws.onerror = event => this.onWsError(event, wsKey);
     ws.onclose = event => this.onWsClose(event, wsKey);

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -398,16 +398,20 @@ export class WebsocketClient extends EventEmitter {
       const expires = Date.now() + timeOffset + 5000;
       const signature = await signMessage('GET/realtime' + expires, secret);
 
+      if (wsKey === wsKeySpotPrivate) {
+        return JSON.stringify({
+          op: 'auth',
+          args: [key, expires, signature]
+        });
+      }
+
       const params: any = {
-        api_key: this.options.key,
+        api_key: key,
         expires: expires,
         signature: signature
       };
 
-      return wsKey === wsKeySpotPrivate ? JSON.stringify({
-        op: 'auth',
-        args: [key, expires, signature]
-      }) : '?' + serializeParams(params);
+      return '?' + serializeParams(params);
 
     } else if (!key || !secret) {
       this.logger.warning('Connot authenticate websocket, either api or private keys missing.', { ...loggerCategory, wsKey });

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -537,14 +537,17 @@ export class WebsocketClient extends EventEmitter {
     (async () => {
       if (wsKey === 'spotPrivate') {
         const { key, secret } = this.options;
-        const timeOffset = await this.restClient.getTimeOffset();
-        const expires = (Date.now() + timeOffset + 5000);
-        const signature = await signMessage('GET/realtime' + expires, secret);
-  
-        this.tryWsSend(wsKey, JSON.stringify({
-          op: 'auth',
-          args: [key, expires, signature]
-        }));
+
+        if (key && secret) {
+          const timeOffset = await this.restClient.getTimeOffset();
+          const expires = (Date.now() + timeOffset + 5000);
+          const signature = await signMessage('GET/realtime' + expires, secret);
+    
+          this.tryWsSend(wsKey, JSON.stringify({
+            op: 'auth',
+            args: [key, expires, signature]
+          }));
+        }
       }
     })();
 


### PR DESCRIPTION
## Summary
Work in progress on completing support for private POST api calls for the spot endpoints, and private websocket topics

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

##  Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] Updated related documentation
- [ ] Updated/added related tests
- [ ] I have tested my changes locally
- [ ] Private inverse APIs work (e.g submitting orders)
- [ ] Private linear APIs work (e.g submitting orders)
- [ ] Private spot APIs work (e.g submitting orders)
