### PR TITLE
reduce_only, close_on_trigger and position_idx are required parameters

### DIFF
--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -82,9 +82,10 @@ export class LinearClient extends SharedEndpoints {
     stop_loss?: number;
     tp_trigger_by?: string;
     sl_trigger_by?: string;
-    reduce_only?: boolean;
-    close_on_trigger?: boolean;
+    reduce_only: boolean;
+    close_on_trigger: boolean;
     order_link_id?: string;
+    position_idx: number;
   }): GenericAPIResponse {
     return this.requestWrapper.post('private/linear/order/create', params);
   }

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -85,7 +85,7 @@ export class LinearClient extends SharedEndpoints {
     reduce_only: boolean;
     close_on_trigger: boolean;
     order_link_id?: string;
-    position_idx: number;
+    position_idx?: number;
   }): GenericAPIResponse {
     return this.requestWrapper.post('private/linear/order/create', params);
   }


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
I did not open an issue. I tried to create new orders and was getting errors, so I figured I'll just fix it, test it and create a pull request.

## Summary
<!--
Thanks for creating this pull request.

Please make sure that the pull request is limited to one type (enhancement, bug, etc.) and keep it as small as possible. You can open multiple PRs instead of opening a huge one.
-->

<!-- Add a brief description of the pr -->

Bybit has made some changes to their API. Namely they now support OneWay and Hedged modes. Therefore to open a position one needs to specify which direction the position should go, so there's a new parameter `position_idx` which can have values 0, 1 or 2. In addition `close_on_trigger` and `reduce_only` are flagged as required parameters, so I adjusted those as well. Here you can find the docs: https://bybit-exchange.github.io/docs/linear/?console#t-placeactive

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

Couldn't create orders on derivatives, now I can :). Tested against the bybit testnet.

##  Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] Updated related documentation
- [ ] Updated/added related tests
- [x] I have tested my changes locally
