### PR TITLE
v2.3.0: fix(#158), disable time sync by default. Optionally avoid hitting time API when connecting authenticated websocket.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ const restClientOptions = {
   recv_window?: number;
 
   // how often to sync time drift with bybit servers
-  sync_interval_ms?: number | string;
+  sync_interval_ms?: number;
 
   // Default: false. Disable above sync mechanism if true.
-  disable_time_sync?: boolean;
+  enable_time_sync?: boolean;
 
   // Default: false. If true, we'll throw errors if any params are undefined
   strict_param_validation?: boolean;

--- a/examples/ws-private.ts
+++ b/examples/ws-private.ts
@@ -27,7 +27,7 @@ import { WebsocketClient, wsKeySpotPublic } from '../src/websocket-client';
       market: market,
       livenet: true,
       restOptions: {
-        // disable_time_sync: true,
+        // enable_time_sync: true,
       },
     },
     logger

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Node.js connector for Bybit's REST APIs and WebSockets, with TypeScript & integration tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -61,10 +61,13 @@ export default abstract class BaseRestClient {
 
     this.options = {
       recv_window: 5000,
-      // how often to sync time drift with bybit servers
-      sync_interval_ms: 3600000,
-      // if true, we'll throw errors if any params are undefined
+
+      /** Throw errors if any params are undefined */
       strict_param_validation: false,
+      /** Disable time sync by default */
+      enable_time_sync: false,
+      /** How often to sync time drift with bybit servers (if time sync is enabled) */
+      sync_interval_ms: 3600000,
       ...options,
     };
 
@@ -86,7 +89,7 @@ export default abstract class BaseRestClient {
       );
     }
 
-    if (this.options.disable_time_sync !== true) {
+    if (this.options.enable_time_sync) {
       this.syncTime();
       setInterval(this.syncTime.bind(this), +this.options.sync_interval_ms!);
     }
@@ -254,10 +257,11 @@ export default abstract class BaseRestClient {
   }
 
   /**
-   * Trigger time sync and store promise
+   * Trigger time sync and store promise. Use force: true, if automatic time sync is disabled
    */
-  private syncTime(): Promise<any> {
-    if (this.options.disable_time_sync === true) {
+  private syncTime(force?: boolean): Promise<any> {
+    if (!force && !this.options.enable_time_sync) {
+      this.timeOffset = 0;
       return Promise.resolve(false);
     }
 

--- a/src/util/requestUtils.ts
+++ b/src/util/requestUtils.ts
@@ -1,21 +1,26 @@
 export interface RestClientOptions {
-  // override the max size of the request window (in ms)
+  /** Override the max size of the request window (in ms) */
   recv_window?: number;
 
-  // how often to sync time drift with bybit servers
-  sync_interval_ms?: number | string;
-
-  // Default: false. Disable above sync mechanism if true.
+  /** @deprecated Time sync is now disabled by default. To re-enable it, use enable_time_sync instead. */
   disable_time_sync?: boolean;
 
-  // Default: false. If true, we'll throw errors if any params are undefined
+  /** Disabled by default. This can help on machines with consistent latency problems. */
+  enable_time_sync?: boolean;
+
+  /** How often to sync time drift with bybit servers */
+  sync_interval_ms?: number | string;
+
+  /** Default: false. If true, we'll throw errors if any params are undefined */
   strict_param_validation?: boolean;
 
-  // Optionally override API protocol + domain
-  // e.g 'https://api.bytick.com'
+  /**
+   * Optionally override API protocol + domain
+   * e.g baseUrl: 'https://api.bytick.com'
+   **/
   baseUrl?: string;
 
-  // Default: true. whether to try and post-process request exceptions.
+  /** Default: true. whether to try and post-process request exceptions. */
   parse_exceptions?: boolean;
 }
 

--- a/test/inverse-futures/private.read.test.ts
+++ b/test/inverse-futures/private.read.test.ts
@@ -6,9 +6,7 @@ describe('Public Inverse-Futures REST API GET Endpoints', () => {
   const API_KEY = process.env.API_KEY_COM;
   const API_SECRET = process.env.API_SECRET_COM;
 
-  const api = new InverseFuturesClient(API_KEY, API_SECRET, useLivenet, {
-    disable_time_sync: true,
-  });
+  const api = new InverseFuturesClient(API_KEY, API_SECRET, useLivenet);
 
   // Warning: if some of these start to fail with 10001 params error, it's probably that this future expired and a newer one exists with a different symbol!
   const symbol = 'BTCUSDU22';

--- a/test/inverse-futures/private.write.test.ts
+++ b/test/inverse-futures/private.write.test.ts
@@ -11,9 +11,7 @@ describe('Private Inverse-Futures REST API POST Endpoints', () => {
     expect(API_SECRET).toStrictEqual(expect.any(String));
   });
 
-  const api = new InverseFuturesClient(API_KEY, API_SECRET, useLivenet, {
-    disable_time_sync: true,
-  });
+  const api = new InverseFuturesClient(API_KEY, API_SECRET, useLivenet);
 
   // Warning: if some of these start to fail with 10001 params error, it's probably that this future expired and a newer one exists with a different symbol!
   const symbol = 'BTCUSDU22';

--- a/test/inverse-futures/public.test.ts
+++ b/test/inverse-futures/public.test.ts
@@ -7,9 +7,7 @@ import {
 
 describe('Public Inverse Futures REST API Endpoints', () => {
   const useLivenet = true;
-  const api = new InverseFuturesClient(undefined, undefined, useLivenet, {
-    disable_time_sync: true,
-  });
+  const api = new InverseFuturesClient(undefined, undefined, useLivenet);
 
   const symbol = 'BTCUSD';
   const interval = '15';

--- a/test/inverse/private.read.test.ts
+++ b/test/inverse/private.read.test.ts
@@ -11,9 +11,7 @@ describe('Private Inverse REST API Endpoints', () => {
     expect(API_SECRET).toStrictEqual(expect.any(String));
   });
 
-  const api = new InverseClient(API_KEY, API_SECRET, useLivenet, {
-    disable_time_sync: true,
-  });
+  const api = new InverseClient(API_KEY, API_SECRET, useLivenet);
 
   const symbol = 'BTCUSD';
 

--- a/test/inverse/private.write.test.ts
+++ b/test/inverse/private.write.test.ts
@@ -12,9 +12,7 @@ describe('Private Inverse REST API Endpoints', () => {
     expect(API_SECRET).toStrictEqual(expect.any(String));
   });
 
-  const api = new InverseClient(API_KEY, API_SECRET, useLivenet, {
-    disable_time_sync: true,
-  });
+  const api = new InverseClient(API_KEY, API_SECRET, useLivenet);
 
   const symbol = 'BTCUSD';
 

--- a/test/inverse/public.test.ts
+++ b/test/inverse/public.test.ts
@@ -7,9 +7,7 @@ import {
 
 describe('Public Inverse REST API Endpoints', () => {
   const useLivenet = true;
-  const api = new InverseClient(undefined, undefined, useLivenet, {
-    disable_time_sync: true,
-  });
+  const api = new InverseClient(undefined, undefined, useLivenet);
 
   const symbol = 'BTCUSD';
   const interval = '15';

--- a/test/linear/private.read.test.ts
+++ b/test/linear/private.read.test.ts
@@ -11,9 +11,7 @@ describe('Public Linear REST API GET Endpoints', () => {
     expect(API_SECRET).toStrictEqual(expect.any(String));
   });
 
-  const api = new LinearClient(API_KEY, API_SECRET, useLivenet, {
-    disable_time_sync: true,
-  });
+  const api = new LinearClient(API_KEY, API_SECRET, useLivenet);
 
   const symbol = 'BTCUSDT';
 

--- a/test/linear/private.write.test.ts
+++ b/test/linear/private.write.test.ts
@@ -11,9 +11,7 @@ describe('Private Inverse-Futures REST API POST Endpoints', () => {
     expect(API_SECRET).toStrictEqual(expect.any(String));
   });
 
-  const api = new LinearClient(API_KEY, API_SECRET, useLivenet, {
-    disable_time_sync: true,
-  });
+  const api = new LinearClient(API_KEY, API_SECRET, useLivenet);
 
   // Warning: if some of these start to fail with 10001 params error, it's probably that this future expired and a newer one exists with a different symbol!
   const symbol = 'BTCUSDT';

--- a/test/linear/public.test.ts
+++ b/test/linear/public.test.ts
@@ -7,9 +7,7 @@ import {
 
 describe('Public Linear REST API Endpoints', () => {
   const useLivenet = true;
-  const api = new LinearClient(undefined, undefined, useLivenet, {
-    disable_time_sync: true,
-  });
+  const api = new LinearClient(undefined, undefined, useLivenet);
 
   const symbol = 'BTCUSDT';
   const interval = '15';

--- a/test/spot/private.read.test.ts
+++ b/test/spot/private.read.test.ts
@@ -16,9 +16,7 @@ describe('Private Spot REST API Endpoints', () => {
     expect(API_SECRET).toStrictEqual(expect.any(String));
   });
 
-  const api = new SpotClient(API_KEY, API_SECRET, useLivenet, {
-    disable_time_sync: true,
-  });
+  const api = new SpotClient(API_KEY, API_SECRET, useLivenet);
 
   const symbol = 'BTCUSDT';
   const interval = '15m';

--- a/test/spot/private.write.test.ts
+++ b/test/spot/private.write.test.ts
@@ -11,9 +11,7 @@ describe('Private Inverse-Futures REST API POST Endpoints', () => {
     expect(API_SECRET).toStrictEqual(expect.any(String));
   });
 
-  const api = new SpotClient(API_KEY, API_SECRET, useLivenet, {
-    disable_time_sync: true,
-  });
+  const api = new SpotClient(API_KEY, API_SECRET, useLivenet);
 
   // Warning: if some of these start to fail with 10001 params error, it's probably that this future expired and a newer one exists with a different symbol!
   const symbol = 'BTCUSDT';

--- a/test/spot/public.test.ts
+++ b/test/spot/public.test.ts
@@ -7,9 +7,7 @@ import {
 
 describe('Public Spot REST API Endpoints', () => {
   const useLivenet = true;
-  const api = new SpotClient(undefined, undefined, useLivenet, {
-    disable_time_sync: true,
-  });
+  const api = new SpotClient(undefined, undefined, useLivenet);
 
   const symbol = 'BTCUSDT';
   const interval = '15m';


### PR DESCRIPTION
## Summary
- Time sync is now disabled by default, as it seems to be causing more issues than it solves.
- Added websocket client option `fetchTimeOffsetBeforeAuth`, disabled by default. If you're frequently seeing recv_window/auth errors with the websocket client, either sync your system time or try to set `fetchTimeOffsetBeforeAuth: true`.
- Updated tests to remove deprecated `disable_time_sync` option.

<!-- Add a brief description of the pr: -->

## Additional Information
- Deprecated `disable_time_sync` in the rest client options, in favour of `enable_time_sync`.

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
