### PR TITLE
Batch sub/unsubscribe to topics for spot v3

### DIFF
--- a/examples/ws-public.ts
+++ b/examples/ws-public.ts
@@ -60,6 +60,8 @@ import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from '../src';
 
   // Spot V3
   // wsClient.subscribe('trade.BTCUSDT');
+  // Or an array of topics
+  // wsClient.subscribe(['trade.BTCUSDT', 'trade.LTCUSDT']);
 
   // usdc options
   // wsClient.subscribe([
@@ -74,11 +76,26 @@ import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from '../src';
   // unified perps
   wsClient.subscribe('publicTrade.BTCUSDT');
 
+  // For spot v1 (the old, deprecated client), request public connection first then send required topics on 'open'
+  // Not necessary for spot v3
+  // wsClient.connectPublic();
+
+  // To unsubscribe from topics:
   // setTimeout(() => {
   //   console.log('unsubscribing');
   //   wsClient.unsubscribe('trade.BTCUSDT');
   // }, 5 * 1000);
 
-  // For spot, request public connection first then send required topics on 'open'
-  // wsClient.connectPublic();
+  // Topics are tracked per websocket type
+  // Get a list of subscribed topics (e.g. for public v3 spot topics)
+  const publicSpotTopics = wsClient
+    .getWsStore()
+    .getTopics(WS_KEY_MAP.spotV3Public);
+
+  console.log('public spot topics: ', publicSpotTopics);
+
+  const privateSpotTopics = wsClient
+    .getWsStore()
+    .getTopics(WS_KEY_MAP.spotV3Private);
+  console.log('private spot topics: ', publicSpotTopics);
 })();

--- a/examples/ws-public.ts
+++ b/examples/ws-public.ts
@@ -16,10 +16,10 @@ import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from '../src';
       // market: 'linear',
       // market: 'inverse',
       // market: 'spot',
-      // market: 'spotv3',
+      market: 'spotv3',
       // market: 'usdcOption',
       // market: 'usdcPerp',
-      market: 'unifiedPerp',
+      // market: 'unifiedPerp',
       // market: 'unifiedOption',
     },
     logger
@@ -59,9 +59,73 @@ import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from '../src';
   // wsClient.subscribe('trade.BTCUSDT');
 
   // Spot V3
-  // wsClient.subscribe('trade.BTCUSDT');
+  wsClient.subscribe('trade.BTCUSDT');
   // Or an array of topics
-  // wsClient.subscribe(['trade.BTCUSDT', 'trade.LTCUSDT']);
+  // wsClient.subscribe([
+  //   'orderbook.40.BTCUSDT',
+  //   'orderbook.40.BTCUSDC',
+  //   'orderbook.40.USDCUSDT',
+  //   'orderbook.40.BTCDAI',
+  //   'orderbook.40.DAIUSDT',
+  //   'orderbook.40.ETHUSDT',
+  //   'orderbook.40.ETHUSDC',
+  //   'orderbook.40.ETHDAI',
+  //   'orderbook.40.XRPUSDT',
+  //   'orderbook.40.XRPUSDC',
+  //   'orderbook.40.EOSUSDT',
+  //   'orderbook.40.EOSUSDC',
+  //   'orderbook.40.DOTUSDT',
+  //   'orderbook.40.DOTUSDC',
+  //   'orderbook.40.XLMUSDT',
+  //   'orderbook.40.XLMUSDC',
+  //   'orderbook.40.LTCUSDT',
+  //   'orderbook.40.LTCUSDC',
+  //   'orderbook.40.DOGEUSDT',
+  //   'orderbook.40.DOGEUSDC',
+  //   'orderbook.40.BITUSDT',
+  //   'orderbook.40.BITUSDC',
+  //   'orderbook.40.BITDAI',
+  //   'orderbook.40.CHZUSDT',
+  //   'orderbook.40.CHZUSDC',
+  //   'orderbook.40.MANAUSDT',
+  //   'orderbook.40.MANAUSDC',
+  //   'orderbook.40.LINKUSDT',
+  //   'orderbook.40.LINKUSDC',
+  //   'orderbook.40.ICPUSDT',
+  //   'orderbook.40.ICPUSDC',
+  //   'orderbook.40.ADAUSDT',
+  //   'orderbook.40.ADAUSDC',
+  //   'orderbook.40.SOLUSDC',
+  //   'orderbook.40.SOLUSDT',
+  //   'orderbook.40.MATICUSDC',
+  //   'orderbook.40.MATICUSDT',
+  //   'orderbook.40.SANDUSDC',
+  //   'orderbook.40.SANDUSDT',
+  //   'orderbook.40.LUNCUSDC',
+  //   'orderbook.40.LUNCUSDT',
+  //   'orderbook.40.SLGUSDC',
+  //   'orderbook.40.SLGUSDT',
+  //   'orderbook.40.AVAXUSDC',
+  //   'orderbook.40.AVAXUSDT',
+  //   'orderbook.40.OPUSDC',
+  //   'orderbook.40.OPUSDT',
+  //   'orderbook.40.OKSEUSDC',
+  //   'orderbook.40.OKSEUSDT',
+  //   'orderbook.40.APEXUSDC',
+  //   'orderbook.40.APEXUSDT',
+  //   'orderbook.40.TRXUSDC',
+  //   'orderbook.40.TRXUSDT',
+  //   'orderbook.40.GMTUSDC',
+  //   'orderbook.40.GMTUSDT',
+  //   'orderbook.40.SHIBUSDC',
+  //   'orderbook.40.SHIBUSDT',
+  //   'orderbook.40.LDOUSDC',
+  //   'orderbook.40.LDOUSDT',
+  //   'orderbook.40.APEUSDC',
+  //   'orderbook.40.APEUSDT',
+  //   'orderbook.40.FILUSDC',
+  //   'orderbook.40.FILUSDT',
+  // ]);
 
   // usdc options
   // wsClient.subscribe([
@@ -74,28 +138,30 @@ import { DefaultLogger, WS_KEY_MAP, WebsocketClient } from '../src';
   // wsClient.subscribe('trade.BTCPERP');
 
   // unified perps
-  wsClient.subscribe('publicTrade.BTCUSDT');
+  // wsClient.subscribe('publicTrade.BTCUSDT');
 
   // For spot v1 (the old, deprecated client), request public connection first then send required topics on 'open'
   // Not necessary for spot v3
   // wsClient.connectPublic();
 
-  // To unsubscribe from topics:
+  // To unsubscribe from topics (after a 5 second delay, in this example):
   // setTimeout(() => {
   //   console.log('unsubscribing');
   //   wsClient.unsubscribe('trade.BTCUSDT');
   // }, 5 * 1000);
 
   // Topics are tracked per websocket type
-  // Get a list of subscribed topics (e.g. for public v3 spot topics)
-  const publicSpotTopics = wsClient
-    .getWsStore()
-    .getTopics(WS_KEY_MAP.spotV3Public);
+  // Get a list of subscribed topics (e.g. for public v3 spot topics) (after a 5 second delay)
+  setTimeout(() => {
+    const publicSpotTopics = wsClient
+      .getWsStore()
+      .getTopics(WS_KEY_MAP.spotV3Public);
 
-  console.log('public spot topics: ', publicSpotTopics);
+    console.log('public spot topics: ', publicSpotTopics);
 
-  const privateSpotTopics = wsClient
-    .getWsStore()
-    .getTopics(WS_KEY_MAP.spotV3Private);
-  console.log('private spot topics: ', publicSpotTopics);
+    const privateSpotTopics = wsClient
+      .getWsStore()
+      .getTopics(WS_KEY_MAP.spotV3Private);
+    console.log('private spot topics: ', privateSpotTopics);
+  }, 5 * 1000);
 })();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Complete & robust node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & integration tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/util/websocket-util.ts
+++ b/src/util/websocket-util.ts
@@ -256,6 +256,28 @@ export function getWsKeyForTopic(
   }
 }
 
+export function getMaxTopicsPerSubscribeEvent(
+  market: APIMarket
+): number | null {
+  switch (market) {
+    case 'inverse':
+    case 'linear':
+    case 'usdcOption':
+    case 'usdcPerp':
+    case 'unifiedOption':
+    case 'unifiedPerp':
+    case 'spot': {
+      return null;
+    }
+    case 'spotv3': {
+      return 10;
+    }
+    default: {
+      throw neverGuard(market, `getWsKeyForTopic(): Unhandled market`);
+    }
+  }
+}
+
 export function getUsdcWsKeyForTopic(
   topic: string,
   subGroup: 'option' | 'perp'

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -174,6 +174,11 @@ export class WebsocketClient extends EventEmitter {
     }
   }
 
+  /** Get the WsStore that tracks websockets & topics */
+  public getWsStore(): WsStore {
+    return this.wsStore;
+  }
+
   public isTestnet(): boolean {
     return this.options.testnet === true;
   }

--- a/test/linear/private.write.test.ts
+++ b/test/linear/private.write.test.ts
@@ -45,7 +45,6 @@ describe('Private Linear REST API POST Endpoints', () => {
       })
     ).toMatchObject({
       ret_code: API_ERROR_CODE.ORDER_NOT_FOUND_OR_TOO_LATE,
-      ret_msg: 'order not exists or too late to cancel',
     });
   });
 
@@ -67,7 +66,6 @@ describe('Private Linear REST API POST Endpoints', () => {
       })
     ).toMatchObject({
       ret_code: API_ERROR_CODE.ORDER_NOT_FOUND_OR_TOO_LATE,
-      ret_msg: 'order not exists or too late to replace',
     });
   });
 
@@ -88,7 +86,6 @@ describe('Private Linear REST API POST Endpoints', () => {
       })
     ).toMatchObject({
       ret_code: API_ERROR_CODE.INSUFFICIENT_BALANCE_FOR_ORDER_COST_LINEAR,
-      ret_msg: 'Insufficient wallet balance',
     });
   });
 
@@ -100,7 +97,6 @@ describe('Private Linear REST API POST Endpoints', () => {
       })
     ).toMatchObject({
       ret_code: API_ERROR_CODE.ORDER_NOT_FOUND_OR_TOO_LATE_LINEAR,
-      ret_msg: 'order not exists or too late to cancel',
     });
   });
 
@@ -122,7 +118,6 @@ describe('Private Linear REST API POST Endpoints', () => {
       })
     ).toMatchObject({
       ret_code: API_ERROR_CODE.ORDER_NOT_FOUND_OR_TOO_LATE_LINEAR,
-      ret_msg: 'order not exists or too late to replace',
     });
   });
 
@@ -135,7 +130,6 @@ describe('Private Linear REST API POST Endpoints', () => {
       })
     ).toMatchObject({
       ret_code: API_ERROR_CODE.AUTO_ADD_MARGIN_NOT_MODIFIED,
-      ret_msg: 'autoAddMargin not modified',
     });
   });
 
@@ -149,7 +143,6 @@ describe('Private Linear REST API POST Endpoints', () => {
       })
     ).toMatchObject({
       ret_code: API_ERROR_CODE.ISOLATED_NOT_MODIFIED_LINEAR,
-      ret_msg: 'Isolated not modified',
     });
   });
 
@@ -161,7 +154,6 @@ describe('Private Linear REST API POST Endpoints', () => {
       })
     ).toMatchObject({
       ret_code: API_ERROR_CODE.POSITION_MODE_NOT_MODIFIED,
-      ret_msg: 'position mode not modified',
     });
   });
 
@@ -173,7 +165,6 @@ describe('Private Linear REST API POST Endpoints', () => {
       })
     ).toMatchObject({
       ret_code: API_ERROR_CODE.SAME_SLTP_MODE_LINEAR,
-      ret_msg: 'same tp sl mode2',
     });
   });
 
@@ -186,7 +177,6 @@ describe('Private Linear REST API POST Endpoints', () => {
       })
     ).toMatchObject({
       ret_code: API_ERROR_CODE.POSITION_SIZE_IS_ZERO,
-      ret_msg: 'position size is zero',
     });
   });
 
@@ -199,7 +189,6 @@ describe('Private Linear REST API POST Endpoints', () => {
       })
     ).toMatchObject({
       ret_code: API_ERROR_CODE.LEVERAGE_NOT_MODIFIED,
-      ret_msg: 'leverage not modified',
     });
   });
 
@@ -212,7 +201,6 @@ describe('Private Linear REST API POST Endpoints', () => {
       })
     ).toMatchObject({
       ret_code: API_ERROR_CODE.CANNOT_SET_LINEAR_TRADING_STOP_FOR_ZERO_POS,
-      ret_msg: 'can not set tp/sl/ts for zero position',
     });
   });
 
@@ -225,7 +213,6 @@ describe('Private Linear REST API POST Endpoints', () => {
       })
     ).toMatchObject({
       ret_code: API_ERROR_CODE.RISK_ID_NOT_MODIFIED,
-      ret_msg: 'risk id not modified',
     });
   });
 });


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->
Looks like only spotv3 has a limitation when subscribing to topics, max 10 per event. This PR adds a batching mechanism to automatically handle that. Fixes #174 

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
