### PR TITLE
fix(shared/types): `max_leverage` typo

### DIFF
--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -134,7 +134,7 @@ export interface AssetExchangeRecordsReq {
 
 export interface LeverageFilter {
   min_leverage: numberInString;
-  max_leveage: numberInString;
+  max_leverage: numberInString;
   leverage_step: numberInString;
 }
 export interface PriceFilter {


### PR DESCRIPTION
Just a typo in typings