### PR TITLE
v3.1.0: fix typo in types (#180), fix tests, fix repeating subscribe/unsubscribe WS events to active connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Complete & robust node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & integration tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/constants/enum.ts
+++ b/src/constants/enum.ts
@@ -51,6 +51,8 @@ export const API_ERROR_CODE = {
   INSUFFICIENT_BALANCE_FOR_ORDER_COST_LINEAR: 130080,
   SAME_SLTP_MODE_LINEAR: 130150,
   RISK_ID_NOT_MODIFIED: 134026,
+  /** E.g. USDC Options trading, trying to access a symbol that is no longer active */
+  CONTRACT_NAME_NOT_EXIST: 3100111,
   ORDER_NOT_EXIST: 3100136,
   NO_ACTIVE_ORDER: 3100205,
   /** E.g. USDC Options trading when the account hasn't been opened for USDC Options yet */

--- a/test/inverse-futures/private.read.test.ts
+++ b/test/inverse-futures/private.read.test.ts
@@ -12,7 +12,27 @@ describe('Private Inverse-Futures REST API GET Endpoints', () => {
   });
 
   // Warning: if some of these start to fail with 10001 params error, it's probably that this future expired and a newer one exists with a different symbol!
-  const symbol = 'BTCUSDU22';
+  let symbol = '';
+
+  beforeAll(async () => {
+    const symbolsResponse = await api.getSymbols();
+
+    const prefix = 'BTCUSD';
+
+    const futuresAsset = symbolsResponse.result
+      .filter((row) => row.name.startsWith(prefix))
+      .find((row) => {
+        const splitSymbol = row.name.split(prefix);
+        return splitSymbol[1] && splitSymbol[1] !== 'T';
+      });
+
+    if (!futuresAsset?.name) {
+      throw new Error('No symbol');
+    }
+
+    symbol = futuresAsset?.name;
+    console.log('Symbol: ', symbol);
+  });
 
   it('getApiKeyInfo()', async () => {
     expect(await api.getApiKeyInfo()).toMatchObject(successResponseObject());

--- a/test/inverse-futures/private.write.test.ts
+++ b/test/inverse-futures/private.write.test.ts
@@ -17,7 +17,27 @@ describe('Private Inverse-Futures REST API POST Endpoints', () => {
   });
 
   // Warning: if some of these start to fail with 10001 params error, it's probably that this future expired and a newer one exists with a different symbol!
-  const symbol = 'BTCUSDU22';
+  let symbol = '';
+
+  beforeAll(async () => {
+    const symbolsResponse = await api.getSymbols();
+
+    const prefix = 'BTCUSD';
+
+    const futuresAsset = symbolsResponse.result
+      .filter((row) => row.name.startsWith(prefix))
+      .find((row) => {
+        const splitSymbol = row.name.split(prefix);
+        return splitSymbol[1] && splitSymbol[1] !== 'T';
+      });
+
+    if (!futuresAsset?.name) {
+      throw new Error('No symbol');
+    }
+
+    symbol = futuresAsset?.name;
+    console.log('Symbol: ', symbol);
+  });
 
   // These tests are primarily check auth is working by expecting balance or order not found style errors
 
@@ -134,7 +154,7 @@ describe('Private Inverse-Futures REST API POST Endpoints', () => {
         take_profit: 50000,
       })
     ).toMatchObject({
-      ret_code: API_ERROR_CODE.POSITION_IDX_NOT_MATCH_POSITION_MODE,
+      ret_code: API_ERROR_CODE.POSITION_STATUS_NOT_NORMAL,
     });
   });
 

--- a/test/usdc/options/private.write.test.ts
+++ b/test/usdc/options/private.write.test.ts
@@ -31,7 +31,7 @@ describe('Private USDC Options REST API POST Endpoints', () => {
         timeInForce: 'GoodTillCancel',
       })
     ).toMatchObject({
-      retCode: API_ERROR_CODE.ACCOUNT_NOT_EXIST,
+      retCode: API_ERROR_CODE.CONTRACT_NAME_NOT_EXIST,
     });
   });
 
@@ -59,8 +59,8 @@ describe('Private USDC Options REST API POST Endpoints', () => {
       ])
     ).toMatchObject({
       result: [
-        { errorCode: API_ERROR_CODE.ACCOUNT_NOT_EXIST },
-        { errorCode: API_ERROR_CODE.ACCOUNT_NOT_EXIST },
+        { errorCode: API_ERROR_CODE.CONTRACT_NAME_NOT_EXIST },
+        { errorCode: API_ERROR_CODE.CONTRACT_NAME_NOT_EXIST },
       ],
     });
   });
@@ -72,7 +72,7 @@ describe('Private USDC Options REST API POST Endpoints', () => {
         orderId: 'somethingFake',
       })
     ).toMatchObject({
-      retCode: API_ERROR_CODE.ORDER_NOT_EXIST,
+      retCode: API_ERROR_CODE.CONTRACT_NAME_NOT_EXIST,
     });
   });
 
@@ -90,8 +90,8 @@ describe('Private USDC Options REST API POST Endpoints', () => {
       ])
     ).toMatchObject({
       result: [
-        { errorCode: API_ERROR_CODE.ORDER_NOT_EXIST },
-        { errorCode: API_ERROR_CODE.ORDER_NOT_EXIST },
+        { errorCode: API_ERROR_CODE.CONTRACT_NAME_NOT_EXIST },
+        { errorCode: API_ERROR_CODE.CONTRACT_NAME_NOT_EXIST },
       ],
     });
   });
@@ -103,7 +103,7 @@ describe('Private USDC Options REST API POST Endpoints', () => {
         orderId: 'somethingFake1',
       })
     ).toMatchObject({
-      retCode: API_ERROR_CODE.ORDER_NOT_EXIST,
+      retCode: API_ERROR_CODE.CONTRACT_NAME_NOT_EXIST,
     });
   });
 
@@ -121,8 +121,8 @@ describe('Private USDC Options REST API POST Endpoints', () => {
       ])
     ).toMatchObject({
       result: [
-        { errorCode: API_ERROR_CODE.ORDER_NOT_EXIST },
-        { errorCode: API_ERROR_CODE.ORDER_NOT_EXIST },
+        { errorCode: API_ERROR_CODE.CONTRACT_NAME_NOT_EXIST },
+        { errorCode: API_ERROR_CODE.CONTRACT_NAME_NOT_EXIST },
       ],
     });
   });


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->
- Fix typo in types (thanks #180).
- Fix overly strict inverse & usdc options tests
- Fix WS subscribe/unsubscribe workflows, which were repeating requests to each active ws connection in the same WS client instance.

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
