### PR TITLE
Update usdt-perp.ts

### DIFF
--- a/src/types/response/usdt-perp.ts
+++ b/src/types/response/usdt-perp.ts
@@ -1,5 +1,5 @@
 export interface PerpPosition {
-  user_id: number;
+  user_id: string;
   symbol: string;
   side: string;
   size: number;
@@ -8,7 +8,7 @@ export interface PerpPosition {
   liq_price: number;
   bust_price: number;
   leverage: number;
-  auto_add_margin: number;
+  auto_add_margin: string;
   is_isolated: boolean;
   position_margin: number;
   occ_closing_fee: number;
@@ -18,11 +18,11 @@ export interface PerpPosition {
   tp_sl_mode: string;
   unrealised_pnl: number;
   deleverage_indicator: number;
-  risk_id: number;
+  risk_id: string;
   stop_loss: number;
   take_profit: number;
   trailing_stop: number;
-  position_idx: number;
+  position_idx: string;
   mode: string;
 }
 


### PR DESCRIPTION
types seem to be incorrect with what is given back

## Summary
`PerpPosition` properties seem to have incorrect types, this PR corrects them

## Additional Information
<img width="277" alt="image" src="https://user-images.githubusercontent.com/111682913/203610334-ce57498f-1f6a-42c4-a46a-fbbd57a618d2.png">

