### PR TITLE
v3.3.4: fix optional param in contract client, add js/ts samples for contract client, fix e2e open interest limit test, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Check out my related projects:
   - [binance](https://www.npmjs.com/package/binance)
   - [bybit-api](https://www.npmjs.com/package/bybit-api)
   - [okx-api](https://www.npmjs.com/package/okx-api)
+  - [bitget-api](https://www.npmjs.com/package/bitget-api)
   - [ftx-api](https://www.npmjs.com/package/ftx-api)
 - Try my misc utilities:
   - [orderbooks](https://www.npmjs.com/package/orderbooks)

--- a/examples/rest-contract-public.js
+++ b/examples/rest-contract-public.js
@@ -1,0 +1,21 @@
+/**
+ * This is the pure javascript version of the `rest-contract-public.ts` sample
+ */
+
+// To use a local build (testing with the repo directly), make sure to `npm run build` first from the repo root
+// const { ContractClient } = require('../dist');
+
+// or, use the version installed with npm
+const { ContractClient } = require('bybit-api');
+
+(async () => {
+  const client = new ContractClient();
+
+  try {
+    const orderbookResult = await client.getOrderBook('BTCUSDT', 'linear');
+    console.log('orderbook result: ', orderbookResult);
+  } catch (e) {
+    console.error('request failed: ', e);
+  }
+
+})();

--- a/examples/rest-contract-public.ts
+++ b/examples/rest-contract-public.ts
@@ -1,0 +1,20 @@
+/**
+ * This is the TypeScript version of the `rest-contract-public.js` sample.
+ */
+
+// For testing with the repo directly, import from the src folder
+import { ContractClient } from '../src';
+
+// or, use the version installed with npm
+// import { ContractClient } from 'bybit-api';
+
+(async () => {
+  const client = new ContractClient();
+
+  try {
+    const orderbookResult = await client.getOrderBook('BTCUSDT', 'linear');
+    console.log('orderbook result: ', orderbookResult);
+  } catch (e) {
+    console.error('request failed: ', e);
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "Complete & robust node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & integration tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/contract-client.ts
+++ b/src/contract-client.ts
@@ -50,7 +50,7 @@ export class ContractClient extends BaseRestClient {
   /** Query order book info. Each side has a depth of 25 orders. */
   getOrderBook(
     symbol: string,
-    category: string,
+    category?: string,
     limit?: number
   ): Promise<APIResponseV3<any>> {
     return this.get('/derivatives/v3/public/order-book/L2', {

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -544,6 +544,7 @@ export class WebsocketClient extends EventEmitter {
 
   private reconnectWithDelay(wsKey: WsKey, connectionDelayMs: number) {
     this.clearTimers(wsKey);
+
     if (
       this.wsStore.getConnectionState(wsKey) !==
       WsConnectionStateEnum.CONNECTING

--- a/test/contract/private.read.test.ts
+++ b/test/contract/private.read.test.ts
@@ -71,11 +71,11 @@ describe('Private Contract REST API GET Endpoints', () => {
     );
   });
 
-  // Doesn't work on e2e test account, something about account state. Investigating with bybit.
-  it.skip('getOpenInterestLimitInfo()', async () => {
+  // Doesn't work on e2e test account. This endpoint throws this error if the account never opened a position before.
+  it('getOpenInterestLimitInfo()', async () => {
     expect(await api.getOpenInterestLimitInfo('ETHUSDT')).toMatchObject({
-      ...successResponseObjectV3(),
-      retMsg: 'ok',
+      retCode: API_ERROR_CODE.PARAMS_MISSING_OR_WRONG,
+      retMsg: expect.stringMatching(/OI group don't exist/gim),
     });
   });
 

--- a/test/response.util.ts
+++ b/test/response.util.ts
@@ -31,6 +31,7 @@ export function successResponseObjectV3() {
   return {
     result: expect.any(Object),
     ...successEmptyResponseObjectV3(),
+    // retMsg: 'ok',
   };
 }
 

--- a/test/response.util.ts
+++ b/test/response.util.ts
@@ -23,7 +23,7 @@ export function successResponseObject(successMsg: string | null = 'OK') {
   return {
     result: expect.any(Object),
     ret_code: API_ERROR_CODE.SUCCESS,
-    ret_msg: successMsg,
+    ret_msg: expect.stringMatching(SUCCESS_MSG_REGEX),
   };
 }
 


### PR DESCRIPTION
## Summary
- Fix param that should be optional in orderbook contract client request
- Add js/ts sample for basic contract client usage without auth.
- Fix E2E test for open interest limit info api call
- Update readme to add bitget connector link
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
