### PR TITLE
v3.5.2: feat() add missing v5 internal deposit records endpoint. fix(#233) return type for v5 wallet balance endpoint, fix(#232) timestamp resolution for v5 fetch time endpoint

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -24,5 +24,6 @@ module.exports = {
       lines: 50,
       statements: -10
     }
-  }
+  },
+  testTimeout: 60 * 15
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,5 +25,5 @@ module.exports = {
       statements: -10
     }
   },
-  testTimeout: 60 * 15
+  testTimeout: 1000 * 15
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -57,6 +57,7 @@ import {
   GetIndexPriceKlineParamsV5,
   GetInstrumentsInfoParamsV5,
   GetInsuranceParamsV5,
+  GetInternalDepositRecordParamsV5,
   GetInternalTransferParamsV5,
   GetKlineParamsV5,
   GetMarkPriceKlineParamsV5,
@@ -77,6 +78,7 @@ import {
   HistoricalVolatilityV5,
   InstrumentInfoResponseV5,
   InsuranceResponseV5,
+  InternalDepositRecordV5,
   InternalTransferRecordV5,
   LeverageTokenInfoV5,
   LeveragedTokenMarketResultV5,
@@ -139,7 +141,7 @@ export class RestClientV5 extends BaseRestClient {
 
   async fetchServerTime(): Promise<number> {
     const res = await this.getServerTime();
-    return Number(res.time);
+    return Number(res.time) / 1000;
   }
 
   getServerTime(): Promise<
@@ -637,7 +639,7 @@ export class RestClientV5 extends BaseRestClient {
    */
   getWalletBalance(
     params: GetWalletBalanceParamsV5
-  ): Promise<APIResponseV3WithTime<WalletBalanceV5>> {
+  ): Promise<APIResponseV3WithTime<{ list: WalletBalanceV5[] }>> {
     return this.getPrivate('/v5/account/wallet-balance', params);
   }
 
@@ -980,6 +982,23 @@ export class RestClientV5 extends BaseRestClient {
     APIResponseV3WithTime<{ rows: DepositRecordV5[]; nextPageCursor: string }>
   > {
     return this.getPrivate('/v5/asset/deposit/query-sub-member-record', params);
+  }
+
+  /**
+   * Get Internal Deposit Records (across Bybit)
+   * Query deposit records through Bybit platform
+   *
+   * RULES
+   * The maximum difference between the start time and the end time is 30 days.
+   * Support to get deposit records by Master or Sub Member Api Key
+   */
+  getInternalDepositRecords(params?: GetInternalDepositRecordParamsV5): Promise<
+    APIResponseV3WithTime<{
+      rows: InternalDepositRecordV5[];
+      nextPageCursor: string;
+    }>
+  > {
+    return this.getPrivate('/v5/asset/deposit/query-internal-record', params);
   }
 
   /**

--- a/src/types/request/v5-asset.ts
+++ b/src/types/request/v5-asset.ts
@@ -95,6 +95,14 @@ export interface GetSubAccountDepositRecordParamsV5 {
   cursor?: string;
 }
 
+export interface GetInternalDepositRecordParamsV5 {
+  startTime?: number;
+  endTime?: number;
+  coin?: string;
+  cursor?: string;
+  limit?: number;
+}
+
 export interface GetWithdrawalRecordsParamsV5 {
   withdrawID?: string;
   coin?: string;

--- a/src/types/response/v5-asset.ts
+++ b/src/types/response/v5-asset.ts
@@ -115,6 +115,16 @@ export interface DepositRecordV5 {
   blockHash: string;
 }
 
+export interface InternalDepositRecordV5 {
+  id: string;
+  type: 1;
+  coin: string;
+  amount: string;
+  status: 1 | 2 | 3;
+  address: string;
+  createdTime: string;
+}
+
 export interface DepositAddressChainV5 {
   chainType: string;
   addressDeposit: string;

--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -81,7 +81,11 @@ export default abstract class BaseRestClient {
 
   private clientType: RestClientType;
 
-  /** Function that calls exchange API to query & resolve server time, used by time sync, disabled by default */
+  /**
+   * Function that calls exchange API to query & resolve server time, used by time sync, disabled by default.
+   *
+   * Note: this should always return server time in seconds
+   */
   abstract fetchServerTime(): Promise<number>;
 
   /** Defines the client type (affecting how requests & signatures behave) */

--- a/src/util/requestUtils.ts
+++ b/src/util/requestUtils.ts
@@ -11,7 +11,12 @@ export interface RestClientOptions {
   /** Override the max size of the request window (in ms) */
   recv_window?: number;
 
-  /** Disabled by default. This can help on machines with consistent latency problems. */
+  /**
+   * Disabled by default.
+   * This can help on machines with consistent latency problems.
+   *
+   * Note: this feature is not recommended as one slow request can cause problems
+   */
   enable_time_sync?: boolean;
 
   /** How often to sync time drift with bybit servers */


### PR DESCRIPTION
## Summary
- feat() add missing v5 internal deposit records endpoint
- fix(#233) return type for v5 wallet balance endpoint
- fix(#232) timestamp resolution for v5 fetch time endpoint

<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
