### PR TITLE
hotfix(v3-linear): fix NewLinearOrder types

### DIFF
--- a/src/types/request/linear.ts
+++ b/src/types/request/linear.ts
@@ -52,16 +52,20 @@ export interface NewLinearOrder {
   symbol: string;
   order_type: LinearOrderType;
   qty: number;
-  price?: number;
+  price?: string;
+  basePrice?: string;
+  triggerPrice?: string;
+  triggerBy?: string;
+  orderIv?: string;
   time_in_force: LinearTimeInForce;
-  take_profit?: number;
-  stop_loss?: number;
+  position_idx?: LinearPositionIdx;
+  order_link_id?: string;
+  take_profit?: string;
+  stop_loss?: string;
   tp_trigger_by?: string;
   sl_trigger_by?: string;
   reduce_only: boolean;
   close_on_trigger: boolean;
-  order_link_id?: string;
-  position_idx?: LinearPositionIdx;
 }
 
 export interface LinearConditionalOrderRequest {


### PR DESCRIPTION
fixes one of the types that have wrong definitions as mentioned in this issue https://github.com/tiagosiebler/bybit-api/issues/237
there may be more types that are wrong.