### PR TITLE
Add syncTimeBeforePrivateRequests option

### DIFF
--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -113,6 +113,8 @@ export default abstract class BaseRestClient {
       enable_time_sync: false,
       /** How often to sync time drift with bybit servers (if time sync is enabled) */
       sync_interval_ms: 3600000,
+      /** Determines whether to perform time synchronization before sending private requests */
+      syncTimeBeforePrivateRequests: false,
       /** Request parameter values are now URI encoded by default during signing. Set to false to override this behaviour. */
       encodeSerialisedValues: true,
       ...restOptions,
@@ -203,6 +205,10 @@ export default abstract class BaseRestClient {
       await this.syncTime();
     }
 
+    if (this.options.syncTimeBeforePrivateRequests) {
+      this.timeOffset = await this.fetchTimeOffset();
+    }
+    
     return this.signRequest(params || {}, method, signMethod);
   }
 

--- a/src/util/requestUtils.ts
+++ b/src/util/requestUtils.ts
@@ -22,6 +22,9 @@ export interface RestClientOptions {
   /** How often to sync time drift with bybit servers */
   sync_interval_ms?: number | string;
 
+  /** Determines whether to perform time synchronization before sending private requests */
+  syncTimeBeforePrivateRequests?: false;
+
   /** Default: false. If true, we'll throw errors if any params are undefined */
   strict_param_validation?: boolean;
 


### PR DESCRIPTION

## Summary
Add forceSync option to decides whether to force time synchronization before sending private requests



