### PR TITLE
Add proxy config to rest client without intercept

### DIFF
--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -108,15 +108,7 @@ export default abstract class BaseRestClient {
     networkOptions: AxiosRequestConfig = {},
   ) {
     this.clientType = this.getClientType();
-    if (this.options.proxy_host){
-      this.proxy = {
-        protocol: 'http',
-        host: this.options.proxy_host,
-        port: this.options.proxy_port!
-      };
-    } else {
-      this.proxy = undefined;
-    }
+
     this.options = {
       recv_window: 5000,
       /** Throw errors if any request params are empty */
@@ -131,6 +123,16 @@ export default abstract class BaseRestClient {
       encodeSerialisedValues: true,
       ...restOptions,
     };
+
+    if (this.options.proxy_host){
+      this.proxy = {
+        protocol: 'http',
+        host: this.options.proxy_host,
+        port: this.options.proxy_port!
+      };
+    } else {
+      this.proxy = undefined;
+    }
 
     this.globalRequestOptions = {
       // in ms == 5 minutes by default

--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -126,7 +126,7 @@ export default abstract class BaseRestClient {
 
     if (this.options.proxy_host){
       this.proxy = {
-        protocol: this.options.proxy_protocol,
+        protocol: this.options.proxy_protocol!,
         host: this.options.proxy_host,
         port: this.options.proxy_port!
       };

--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -85,6 +85,8 @@ export default abstract class BaseRestClient {
   private secret: string | undefined;
 
   private clientType: RestClientType;
+  
+  private proxy: { protocol: string; host: string; port: number; } | undefined;
 
   /**
    * Function that calls exchange API to query & resolve server time, used by time sync, disabled by default.
@@ -106,7 +108,15 @@ export default abstract class BaseRestClient {
     networkOptions: AxiosRequestConfig = {},
   ) {
     this.clientType = this.getClientType();
-
+    if (this.options.proxy_host){
+      this.proxy = {
+        protocol: 'http',
+        host: this.options.proxy_host,
+        port: this.options.proxy_port!
+      };
+    } else {
+      this.proxy = undefined;
+    }
     this.options = {
       recv_window: 5000,
       /** Throw errors if any request params are empty */
@@ -225,6 +235,7 @@ export default abstract class BaseRestClient {
       ...this.globalRequestOptions,
       url: url,
       method: method,
+      proxy:this.proxy
     };
 
     for (const key in params) {

--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -126,7 +126,7 @@ export default abstract class BaseRestClient {
 
     if (this.options.proxy_host){
       this.proxy = {
-        protocol: 'http',
+        protocol: this.options.proxy_protocol,
         host: this.options.proxy_host,
         port: this.options.proxy_port!
       };

--- a/src/util/requestUtils.ts
+++ b/src/util/requestUtils.ts
@@ -47,6 +47,8 @@ export interface RestClientOptions {
   proxy_host?: string;
 
   proxy_port?: number;
+
+  proxy_protocol?: string;
 }
 
 /**

--- a/src/util/requestUtils.ts
+++ b/src/util/requestUtils.ts
@@ -43,6 +43,10 @@ export interface RestClientOptions {
 
   /** Default: true. whether to try and post-process request exceptions. */
   parse_exceptions?: boolean;
+
+  proxy_host?: string;
+
+  proxy_port?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
Added proxy configuration for BaseRestClient to allow going through a proxy server
new configuration added: proxy_host, proxy_port, proxy_protocol
## Additional Information
old behavior will not be affected if no proxy configuration is supplied
## Testing
Tested and verified with caddy reverse proxy, I was able to send order to bybit through it.