### PR TITLE
v3.7.0: add missing v5 endpoints, add new tpsl request/response v3 & v5 parameters, add rest api samples for docs

### DIFF
--- a/examples/apidoc/README.md
+++ b/examples/apidoc/README.md
@@ -1,0 +1,3 @@
+# API Doc Examples
+
+These are per-endpoint JavaScript examples also found in Bybit's API documentation website, demonstrating how to interact with each endpoint with the Node.js SDK.

--- a/examples/apidoc/V5/Account/README.md
+++ b/examples/apidoc/V5/Account/README.md
@@ -1,0 +1,3 @@
+# V5 - REST - Account
+
+https://bybit-exchange.github.io/docs/v5/account/wallet-balance

--- a/examples/apidoc/V5/Account/get-account-info.js
+++ b/examples/apidoc/V5/Account/get-account-info.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getAccountInfo()
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Account/get-coin-greeks.js
+++ b/examples/apidoc/V5/Account/get-coin-greeks.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getCoinGreeks('BTC')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Account/get-collateral-info.js
+++ b/examples/apidoc/V5/Account/get-collateral-info.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getCollateralInfo('BTC')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Account/get-fee-rate.js
+++ b/examples/apidoc/V5/Account/get-fee-rate.js
@@ -1,0 +1,19 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getFeeRate({
+    category: 'linear',
+    symbol: 'ETHUSDT',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Account/get-mmp-state.js
+++ b/examples/apidoc/V5/Account/get-mmp-state.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getMMPState('ETH')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Account/get-transaction-log.js
+++ b/examples/apidoc/V5/Account/get-transaction-log.js
@@ -1,0 +1,20 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getTransactionLog({
+    accountType: 'UNIFIED',
+    category: 'linear',
+    currency: 'USDT',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Account/get-wallet-balance.js
+++ b/examples/apidoc/V5/Account/get-wallet-balance.js
@@ -1,0 +1,19 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getWalletBalance({
+    accountType: 'UNIFIED',
+    coin: 'BTC',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Account/reset-mmp.js
+++ b/examples/apidoc/V5/Account/reset-mmp.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .resetMMP('ETH')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Account/set-margin-mode.js
+++ b/examples/apidoc/V5/Account/set-margin-mode.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .setMarginMode('PORTFOLIO_MARGIN')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Account/set-mmp.js
+++ b/examples/apidoc/V5/Account/set-mmp.js
@@ -1,0 +1,22 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .setMMP({
+    baseCoin: 'ETH',
+    window: '5000',
+    frozenPeriod: '100000',
+    qtyLimit: '50',
+    deltaLimit: '20',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Account/upgrade-to-unified-account.js
+++ b/examples/apidoc/V5/Account/upgrade-to-unified-account.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .upgradeToUnifiedAccount()
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/README.md
+++ b/examples/apidoc/V5/Asset/README.md
@@ -1,0 +1,3 @@
+# V5 - REST - Asset
+
+https://bybit-exchange.github.io/docs/v5/asset/exchange

--- a/examples/apidoc/V5/Asset/cancel-withdrawal.js
+++ b/examples/apidoc/V5/Asset/cancel-withdrawal.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .cancelWithdrawal('10197')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/create-internal-transfer.js
+++ b/examples/apidoc/V5/Asset/create-internal-transfer.js
@@ -1,0 +1,22 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .createInternalTransfer(
+    '42c0cfb0-6bca-c242-bc76-4e6df6cbcb16',
+    'BTC',
+    '0.05',
+    'UNIFIED',
+    'CONTRACT',
+  )
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/create-universal-transfer.js
+++ b/examples/apidoc/V5/Asset/create-universal-transfer.js
@@ -1,0 +1,24 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .createUniversalTransfer({
+    transferId: 'be7a2462-1138-4e27-80b1-62653f24925e',
+    coin: 'ETH',
+    amount: '0.5',
+    fromMemberId: 592334,
+    toMemberId: 691355,
+    fromAccountType: 'CONTRACT',
+    toAccountType: 'UNIFIED',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/enable-universal-transfer-for-sub-uid.js
+++ b/examples/apidoc/V5/Asset/enable-universal-transfer-for-sub-uid.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .enableUniversalTransferForSubUIDs(['554117', '592324', '592334'])
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-all-coins-balance.js
+++ b/examples/apidoc/V5/Asset/get-all-coins-balance.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getAllCoinsBalance({ accountType: 'FUND', coin: 'USDC' })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-allowed-deposit-coin-info.js
+++ b/examples/apidoc/V5/Asset/get-allowed-deposit-coin-info.js
@@ -1,0 +1,19 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getAllowedDepositCoinInfo({
+    coin:"ETH",
+    chain:"ETH",
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-asset-info-spot.js
+++ b/examples/apidoc/V5/Asset/get-asset-info-spot.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getAssetInfo({ accountType: 'FUND', coin: 'USDC' })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-coin-exchange-records.js
+++ b/examples/apidoc/V5/Asset/get-coin-exchange-records.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getCoinExchangeRecords({ limit: 10 })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-coin-info.js
+++ b/examples/apidoc/V5/Asset/get-coin-info.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getCoinInfo('ETH')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-delivery-record.js
+++ b/examples/apidoc/V5/Asset/get-delivery-record.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getDeliveryRecord({ category: 'option', expDate: '29DEC22' })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-deposit-records.js
+++ b/examples/apidoc/V5/Asset/get-deposit-records.js
@@ -1,0 +1,18 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getDepositRecords({
+    coin: 'USDT'
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-internal-deposit-records.js
+++ b/examples/apidoc/V5/Asset/get-internal-deposit-records.js
@@ -1,0 +1,19 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getInternalDepositRecords({
+    startTime: 1667260800000,
+    endTime: 1667347200000,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-internal-transfer-records.js
+++ b/examples/apidoc/V5/Asset/get-internal-transfer-records.js
@@ -1,0 +1,19 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getInternalTransferRecords({
+    coin: 'USDT',
+    limit: 1,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-master-deposit-address.js
+++ b/examples/apidoc/V5/Asset/get-master-deposit-address.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getMasterDepositAddress('USDT', 'ETH')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-single-coin-balance.js
+++ b/examples/apidoc/V5/Asset/get-single-coin-balance.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getAllCoinsBalance({ accountType: 'FUND', coin: 'USDC' })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-sub-deposit-address.js
+++ b/examples/apidoc/V5/Asset/get-sub-deposit-address.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getSubDepositAddress('USDT', 'TRX', '592334')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-sub-deposit-records.js
+++ b/examples/apidoc/V5/Asset/get-sub-deposit-records.js
@@ -1,0 +1,20 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getSubAccountDepositRecords({
+    coin: 'USDT',
+    limit: 1,
+    subMemberId: '592334',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-sub-uid.js
+++ b/examples/apidoc/V5/Asset/get-sub-uid.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getSubUID()
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-transferable-coin.js
+++ b/examples/apidoc/V5/Asset/get-transferable-coin.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getTransferableCoinList('UNIFIED', 'CONTRACT')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-universal-transfer-records.js
+++ b/examples/apidoc/V5/Asset/get-universal-transfer-records.js
@@ -1,0 +1,19 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getUniversalTransferRecords({
+    limit: 1,
+    cursor: 'eyJtaW5JRCI6MTc5NjU3OCwibWF4SUQiOjE3OTY1Nzh9',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-usdc-session-settlement.js
+++ b/examples/apidoc/V5/Asset/get-usdc-session-settlement.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getSettlementRecords({ category: 'linear' })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-withdrawable-amount.js
+++ b/examples/apidoc/V5/Asset/get-withdrawable-amount.js
@@ -1,0 +1,18 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getWithdrawableAmount({
+    coin: 'USDT',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/get-withdrawal-records.js
+++ b/examples/apidoc/V5/Asset/get-withdrawal-records.js
@@ -1,0 +1,20 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getWithdrawalRecords({
+    coin: 'USDT',
+    withdrawType: 2,
+    limit: 2,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/set-deposit-account.js
+++ b/examples/apidoc/V5/Asset/set-deposit-account.js
@@ -1,0 +1,18 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .setDepositAccount({
+    accountType: 'CONTRACT'
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Asset/withdraw.js
+++ b/examples/apidoc/V5/Asset/withdraw.js
@@ -1,0 +1,24 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .submitWithdrawal({
+    coin: 'USDT',
+    chain: 'ETH',
+    address: '0x99ced129603abc771c0dabe935c326ff6c86645d',
+    amount: '24',
+    timestamp: 1672196561407,
+    forceChain: 0,
+    accountType: 'FUND',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Market/README.md
+++ b/examples/apidoc/V5/Market/README.md
@@ -1,0 +1,3 @@
+# V5 - REST - Market
+
+https://bybit-exchange.github.io/docs/v5/market/kline

--- a/examples/apidoc/V5/Market/get-delivery-price.js
+++ b/examples/apidoc/V5/Market/get-delivery-price.js
@@ -1,0 +1,17 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+});
+
+client
+  .getTickers({
+    category: 'inverse',
+    symbol: 'BTCUSDT',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Market/get-delivery-price.js
+++ b/examples/apidoc/V5/Market/get-delivery-price.js
@@ -5,10 +5,7 @@ const client = new RestClientV5({
 });
 
 client
-  .getTickers({
-    category: 'inverse',
-    symbol: 'BTCUSDT',
-  })
+  .getDeliveryPrice({ category: 'option', symbol: 'ETH-26DEC22-1400-C' })
   .then((response) => {
     console.log(response);
   })

--- a/examples/apidoc/V5/Market/get-funding-rate-history.js
+++ b/examples/apidoc/V5/Market/get-funding-rate-history.js
@@ -1,0 +1,18 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+});
+
+client
+  .getFundingRateHistory({
+    category: 'linear',
+    symbol: 'ETHPERP',
+    limit: 1,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Market/get-historical-volatility.js
+++ b/examples/apidoc/V5/Market/get-historical-volatility.js
@@ -1,0 +1,18 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+});
+
+client
+  .getHistoricalVolatility({
+    category: 'option',
+    baseCoin: 'ETH',
+    period: 30,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Market/get-instruments-info.js
+++ b/examples/apidoc/V5/Market/get-instruments-info.js
@@ -1,0 +1,17 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+});
+
+client
+  .getInstrumentsInfo({
+    category: 'linear',
+    symbol: 'BTCUSDT',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Market/get-insurance.js
+++ b/examples/apidoc/V5/Market/get-insurance.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+});
+
+client
+  .getInsurance({
+    coin: 'ETH',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Market/get-kline-index-price.js
+++ b/examples/apidoc/V5/Market/get-kline-index-price.js
@@ -1,0 +1,21 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+});
+
+client
+  .getIndexPriceKline({
+    category: 'inverse',
+    symbol: 'BTCUSDZ22',
+    interval: '1',
+    start: 1670601600000,
+    end: 1670608800000,
+    limit: 2,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Market/get-kline-mark-price.js
+++ b/examples/apidoc/V5/Market/get-kline-mark-price.js
@@ -1,0 +1,21 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+});
+
+client
+  .getMarkPriceKline({
+    category: 'linear',
+    symbol: 'BTCUSD',
+    interval: '15',
+    start: 1670601600000,
+    end: 1670608800000,
+    limit: 1,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Market/get-kline-premium-index-price.js
+++ b/examples/apidoc/V5/Market/get-kline-premium-index-price.js
@@ -1,0 +1,20 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+});
+
+client
+  .getPremiumIndexPriceKline({
+    category: 'linear',
+    symbol: 'BTCUSDT',
+    interval: 'D',
+    start: 1652112000000,
+    end: 1652544000000,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Market/get-kline.js
+++ b/examples/apidoc/V5/Market/get-kline.js
@@ -1,0 +1,20 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+});
+
+client
+  .getKline({
+    category: 'inverse',
+    symbol: 'BTCUSD',
+    interval: '60',
+    start: 1670601600000,
+    end: 1670608800000,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Market/get-open-interest.js
+++ b/examples/apidoc/V5/Market/get-open-interest.js
@@ -1,0 +1,20 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+});
+
+client
+  .getOpenInterest({
+    category: 'inverse',
+    symbol: 'BTCUSD',
+    intervalTime: '5min',
+    startTime: 1669571100000,
+    endTime: 1669571400000,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Market/get-orderbook.js
+++ b/examples/apidoc/V5/Market/get-orderbook.js
@@ -1,0 +1,17 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+});
+
+client
+  .getOrderbook({
+    category: 'linear',
+    symbol: 'BTCUSDT',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Market/get-public-trading-history.js
+++ b/examples/apidoc/V5/Market/get-public-trading-history.js
@@ -1,0 +1,18 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+});
+
+client
+  .getPublicTradingHistory({
+    category: 'spot',
+    symbol: 'BTCUSDT',
+    limit: 1,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Market/get-risk-limit.js
+++ b/examples/apidoc/V5/Market/get-risk-limit.js
@@ -1,0 +1,17 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+});
+
+client
+  .getRiskLimit({
+    category: 'inverse',
+    symbol: 'BTCUSD',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Market/get-tickers.js
+++ b/examples/apidoc/V5/Market/get-tickers.js
@@ -1,0 +1,17 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+});
+
+client
+  .getTickers({
+    category: 'inverse',
+    symbol: 'BTCUSDT',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Position/README.md
+++ b/examples/apidoc/V5/Position/README.md
@@ -1,0 +1,3 @@
+# V5 - REST - Position
+
+https://bybit-exchange.github.io/docs/v5/position

--- a/examples/apidoc/V5/Position/add-or-reduce-margin.js
+++ b/examples/apidoc/V5/Position/add-or-reduce-margin.js
@@ -1,0 +1,20 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .addOrReduceMargin({
+    category: 'linear',
+    symbol: 'BTCUSDT',
+    margin: '10',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Position/get-closed-pnl.js
+++ b/examples/apidoc/V5/Position/get-closed-pnl.js
@@ -1,0 +1,19 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getClosedPnL({
+    category: 'linear',
+    limit: 1,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Position/get-execution.js
+++ b/examples/apidoc/V5/Position/get-execution.js
@@ -1,0 +1,20 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .addOrReduceMargin({
+    category: 'linear',
+    symbol: 'BTCUSDT',
+    margin: '10',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Position/get-position-info.js
+++ b/examples/apidoc/V5/Position/get-position-info.js
@@ -1,0 +1,19 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getPositionInfo({
+    category: 'inverse',
+    symbol: 'BTCUSD',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Position/set-auto-add-margin.js
+++ b/examples/apidoc/V5/Position/set-auto-add-margin.js
@@ -1,0 +1,20 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .setAutoAddMargin({
+    category: 'linear',
+    symbol: 'BTCUSDT',
+    autoAddMargin: 1,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Position/set-leverage.js
+++ b/examples/apidoc/V5/Position/set-leverage.js
@@ -1,0 +1,21 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .setLeverage({
+    category: 'linear',
+    symbol: 'BTCUSDT',
+    buyLeverage: '6',
+    sellLeverage: '6',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Position/set-risk-limit.js
+++ b/examples/apidoc/V5/Position/set-risk-limit.js
@@ -1,0 +1,20 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .setRiskLimit({
+    category: 'linear',
+    symbol: 'BTCUSDT',
+    riskId: 4,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Position/set-tpsl-mode.js
+++ b/examples/apidoc/V5/Position/set-tpsl-mode.js
@@ -1,0 +1,20 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .setTPSLMode({
+    symbol: 'XRPUSDT',
+    category: 'linear',
+    tpSlMode: 'Full',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Position/set-trading-stop.js
+++ b/examples/apidoc/V5/Position/set-trading-stop.js
@@ -1,0 +1,31 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .setTradingStop({
+    category: 'linear',
+    symbol: 'XRPUSDT',
+    takeProfit: '0.5',
+    stopLoss: '0.2',
+    tpTriggerBy: 'MarkPrice',
+    slTriggerBy: 'IndexPrice',
+    tpslMode: 'Partial',
+    tpOrderType: 'Limit',
+    slOrderType: 'Limit',
+    tpSize: '50',
+    slSize: '50',
+    tpLimitPrice: '0.49',
+    slLimitPrice: '0.21',
+    positionIdx: 0,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Position/switch-cross-isolated-margin.js
+++ b/examples/apidoc/V5/Position/switch-cross-isolated-margin.js
@@ -1,0 +1,22 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .switchIsolatedMargin({
+    category: 'linear',
+    symbol: 'ETHUSDT',
+    tradeMode: 1,
+    buyLeverage: '10',
+    sellLeverage: '10',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Position/switch-position-mode.js
+++ b/examples/apidoc/V5/Position/switch-position-mode.js
@@ -1,0 +1,20 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .switchPositionMode({
+    category: 'inverse',
+    symbol: 'BTCUSDH23',
+    mode: 0,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Leverage-Token/README.md
+++ b/examples/apidoc/V5/Spot-Leverage-Token/README.md
@@ -1,0 +1,3 @@
+# V5 - REST - Spot Leverage Token
+
+https://bybit-exchange.github.io/docs/v5/lt/leverage-token-info

--- a/examples/apidoc/V5/Spot-Leverage-Token/get-leverage-token-info.js
+++ b/examples/apidoc/V5/Spot-Leverage-Token/get-leverage-token-info.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getLeveragedTokenInfo('BTC3L')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Leverage-Token/get-leveraged-token-market.js
+++ b/examples/apidoc/V5/Spot-Leverage-Token/get-leveraged-token-market.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getLeveragedTokenMarket('BTC3L')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Leverage-Token/get-purchase-redemption-records.js
+++ b/examples/apidoc/V5/Spot-Leverage-Token/get-purchase-redemption-records.js
@@ -1,0 +1,18 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getSpotLeveragedTokenOrderHistory({
+    orderId: '2611',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Leverage-Token/purchase.js
+++ b/examples/apidoc/V5/Spot-Leverage-Token/purchase.js
@@ -1,0 +1,20 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .purchaseSpotLeveragedToken({
+    ltCoin: 'EOS3L',
+    amount: '200',
+    serialNo: 'purchase-001',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Leverage-Token/redeem.js
+++ b/examples/apidoc/V5/Spot-Leverage-Token/redeem.js
@@ -1,0 +1,20 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .redeemSpotLeveragedToken({
+    ltCoin: 'EOS3L',
+    quantity: '200',
+    serialNo: 'redeem-001',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/README.md
+++ b/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/README.md
@@ -1,0 +1,3 @@
+# V5 - REST - Spot Margin Trade (Normal)
+
+https://bybit-exchange.github.io/docs/v5/spot-margin-normal/margin-data

--- a/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/borrow.js
+++ b/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/borrow.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .spotMarginBorrow({ coin: 'ETH', qty: '10' })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-borrow-order-detail.js
+++ b/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-borrow-order-detail.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getSpotMarginBorrowOrderDetail({ coin: 'ETH', limit: 1, status: 2 })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-borrowable-coin-info.js
+++ b/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-borrowable-coin-info.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getSpotMarginBorrowableCoinInfo('ETH')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-interest-and-quota.js
+++ b/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-interest-and-quota.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getSpotMarginInterestAndQuota('ETH')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-loan-account-info.js
+++ b/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-loan-account-info.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getSpotMarginLoanAccountInfo()
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-margin-coin-info.js
+++ b/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-margin-coin-info.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getSpotMarginCoinInfo('ETH')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-repayment-order-detail.js
+++ b/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/get-repayment-order-detail.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getSpotMarginRepaymentOrderDetail({ coin: 'ETH', limit: 1 })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/repay.js
+++ b/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/repay.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .spotMarginRepay({ coin: 'ETH', completeRepayment: 1 })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/toggle-margin-trade-normal.js
+++ b/examples/apidoc/V5/Spot-Margin-Trade-(Normal)/toggle-margin-trade-normal.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .toggleSpotCrossMarginTrade({ switch: 0 })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Margin-Trade-(UTA)/README.md
+++ b/examples/apidoc/V5/Spot-Margin-Trade-(UTA)/README.md
@@ -1,0 +1,3 @@
+# V5 - REST - Spot Margin Trade (UTA)
+
+https://bybit-exchange.github.io/docs/v5/spot-margin-uta/switch-mode

--- a/examples/apidoc/V5/Spot-Margin-Trade-(UTA)/set-leverage.js
+++ b/examples/apidoc/V5/Spot-Margin-Trade-(UTA)/set-leverage.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .setSpotMarginLeverage('4')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Spot-Margin-Trade-(UTA)/toggle-margin-trade.js
+++ b/examples/apidoc/V5/Spot-Margin-Trade-(UTA)/toggle-margin-trade.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .toggleSpotMarginTrade('0')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Trade/README.md
+++ b/examples/apidoc/V5/Trade/README.md
@@ -1,0 +1,3 @@
+# V5 - REST - Trade
+
+https://bybit-exchange.github.io/docs/v5/order/create-order

--- a/examples/apidoc/V5/Trade/amend-order.js
+++ b/examples/apidoc/V5/Trade/amend-order.js
@@ -1,0 +1,25 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .submitOrder({
+    category: 'linear',
+    symbol: 'ETHPERP',
+    orderLinkId: 'linear-004',
+    triggerPrice: '1145',
+    qty: '0.15',
+    price: '1050',
+    takeProfit: '0',
+    stopLoss: '0',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Trade/batch-amend-order.js
+++ b/examples/apidoc/V5/Trade/batch-amend-order.js
@@ -1,0 +1,27 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .batchAmendOrders('option', [
+    {
+      symbol: 'ETH-30DEC22-500-C',
+      orderIv: '6.8',
+      orderId: 'b551f227-7059-4fb5-a6a6-699c04dbd2f2',
+    },
+    {
+      symbol: 'ETH-30DEC22-700-C',
+      price: '650',
+      orderId: 'fa6a595f-1a57-483f-b9d3-30e9c8235a52',
+    },
+  ])
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Trade/batch-cancel-order.js
+++ b/examples/apidoc/V5/Trade/batch-cancel-order.js
@@ -1,0 +1,25 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .batchCancelOrders('option', [
+    {
+      symbol: 'ETH-30DEC22-500-C',
+      orderId: 'b551f227-7059-4fb5-a6a6-699c04dbd2f2',
+    },
+    {
+      symbol: 'ETH-30DEC22-700-C',
+      orderId: 'fa6a595f-1a57-483f-b9d3-30e9c8235a52',
+    },
+  ])
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Trade/batch-place-order.js
+++ b/examples/apidoc/V5/Trade/batch-place-order.js
@@ -1,0 +1,39 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .batchSubmitOrders('option', [
+    {
+      symbol: 'ETH-30DEC22-500-C',
+      orderType: 'Limit',
+      side: 'Buy',
+      qty: '1',
+      orderIv: '6',
+      timeInForce: 'GTC',
+      orderLinkId: 'option-test-001',
+      mmp: false,
+      reduceOnly: false,
+    },
+    {
+      symbol: 'ETH-30DEC22-700-C',
+      orderType: 'Limit',
+      side: 'Sell',
+      qty: '2',
+      price: '700',
+      timeInForce: 'GTC',
+      orderLinkId: 'option-test-001',
+      mmp: false,
+      reduceOnly: false,
+    },
+  ])
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Trade/cancel-all-orders.js
+++ b/examples/apidoc/V5/Trade/cancel-all-orders.js
@@ -1,0 +1,19 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .cancelAllOrders({
+    category: 'linear',
+    settleCoin: 'USDT',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Trade/cancel-order.js
+++ b/examples/apidoc/V5/Trade/cancel-order.js
@@ -1,0 +1,20 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .cancelOrder({
+    category: 'linear',
+    symbol: 'BTCPERP',
+    orderId: 'c6f055d9-7f21-4079-913d-e6523a9cfffa',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Trade/get-open-orders.js
+++ b/examples/apidoc/V5/Trade/get-open-orders.js
@@ -1,0 +1,21 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getActiveOrders({
+    category: 'linear',
+    symbol: 'ETHUSDT',
+    openOnly: 0,
+    limit: 1,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Trade/get-order-history.js
+++ b/examples/apidoc/V5/Trade/get-order-history.js
@@ -1,0 +1,19 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getHistoricOrders({
+    category: 'linear',
+    limit: 1,
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Trade/get-spot-borrow-quota.js
+++ b/examples/apidoc/V5/Trade/get-spot-borrow-quota.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getSpotBorrowCheck('BTCUSDT', 'Buy')
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Trade/place-order.js
+++ b/examples/apidoc/V5/Trade/place-order.js
@@ -1,0 +1,27 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .submitOrder({
+    category: 'spot',
+    symbol: 'BTCUSDT',
+    side: 'Buy',
+    orderType: 'Market',
+    qty: '0.1',
+    price: '15600',
+    timeInForce: 'PostOnly',
+    orderLinkId: 'spot-test-postonly',
+    isLeverage: 0,
+    orderFilter: 'Order',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/Trade/set-dcp.js
+++ b/examples/apidoc/V5/Trade/set-dcp.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .setDisconnectCancelAllWindow('option', 40)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/User/README.md
+++ b/examples/apidoc/V5/User/README.md
@@ -1,0 +1,3 @@
+# V5 - REST - User
+
+https://bybit-exchange.github.io/docs/v5/user/create-subuid

--- a/examples/apidoc/V5/User/create-sub-uid-api-key.js
+++ b/examples/apidoc/V5/User/create-sub-uid-api-key.js
@@ -1,0 +1,23 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .createSubUIDAPIKey({
+    subuid: 53888000,
+    note: 'testxxx',
+    readOnly: 0,
+    permissions: {
+      Wallet: ['AccountTransfer'],
+    },
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/User/create-sub-uid.js
+++ b/examples/apidoc/V5/User/create-sub-uid.js
@@ -1,0 +1,21 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .createSubMember({
+    username: 'xxxxx',
+    memberType: 1,
+    switch: 1,
+    note: 'test',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/User/delete-master-api-key.js
+++ b/examples/apidoc/V5/User/delete-master-api-key.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .deleteMasterApiKey()
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/User/delete-sub-api-key.js
+++ b/examples/apidoc/V5/User/delete-sub-api-key.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .deleteSubApiKey()
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/User/freeze-sub-uid.js
+++ b/examples/apidoc/V5/User/freeze-sub-uid.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .setSubUIDFrozenState(53888001, 1)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/User/get-affiliate-user-info.js
+++ b/examples/apidoc/V5/User/get-affiliate-user-info.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .deleteSubApiKey()
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/User/get-api-key-info.js
+++ b/examples/apidoc/V5/User/get-api-key-info.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getQueryApiKey()
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/User/get-sub-uid-list.js
+++ b/examples/apidoc/V5/User/get-sub-uid-list.js
@@ -1,0 +1,16 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getSubUIDList()
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/User/modify-master-api-key.js
+++ b/examples/apidoc/V5/User/modify-master-api-key.js
@@ -1,0 +1,29 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .updateMasterApiKey({
+    ips: ['*'],
+    permissions: {
+      ContractTrade: ['Order', 'Position'],
+      Spot: ['SpotTrade'],
+      Wallet: ['AccountTransfer', 'SubMemberTransfer'],
+      Options: ['OptionsTrade'],
+      Derivatives: ['DerivativesTrade'],
+      CopyTrading: ['CopyTrading'],
+      BlockTrade: [],
+      Exchange: ['ExchangeHistory'],
+      NFT: ['NFTQueryProductList'],
+    },
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/V5/User/modify-sub-api-key.js
+++ b/examples/apidoc/V5/User/modify-sub-api-key.js
@@ -1,0 +1,30 @@
+const { RestClientV5 } = require('bybit-api');
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .updateSubApiKey({
+    readOnly: 0,
+    ips: ['*'],
+    permissions: {
+      ContractTrade: [],
+      Spot: ['SpotTrade'],
+      Wallet: ['AccountTransfer'],
+      Options: [],
+      Derivatives: [],
+      CopyTrading: [],
+      BlockTrade: [],
+      Exchange: [],
+      NFT: [],
+    },
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/typescripttest.ts
+++ b/examples/apidoc/typescripttest.ts
@@ -1,0 +1,19 @@
+import { RestClientV5 } from '../../src';
+
+const client = new RestClientV5({
+  testnet: true,
+  key: 'apikey',
+  secret: 'apisecret',
+});
+
+client
+  .getDeliveryPrice({
+    category: 'option',
+    symbol: 'ETH-26DEC22-1400-C"',
+  })
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/rest-linear-public.ts
+++ b/examples/rest-linear-public.ts
@@ -1,0 +1,23 @@
+import { LinearClient } from '../src/index';
+
+// or
+// import { LinearClient } from 'bybit-api';
+
+const client = new LinearClient();
+
+(async () => {
+  try {
+    // console.log('getSymbols: ', await client.getSymbols());
+    // console.log('getOrderBook: ', await client.getOrderBook(symbol));
+    console.log(
+      'getKline: ',
+      await client.getKline({
+        symbol: 'ETHUSDT',
+        interval: 'D',
+        from: 1,
+      }),
+    );
+  } catch (e) {
+    console.error('request failed: ', e);
+  }
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bybit-api",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bybit-api",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/contract-client.ts
+++ b/src/contract-client.ts
@@ -54,7 +54,7 @@ export class ContractClient extends BaseRestClient {
   getOrderBook(
     symbol: string,
     category?: string,
-    limit?: number
+    limit?: number,
   ): Promise<APIResponseV3<any>> {
     return this.get('/derivatives/v3/public/order-book/L2', {
       category,
@@ -71,14 +71,14 @@ export class ContractClient extends BaseRestClient {
   /** Get a symbol price/statistics ticker */
   getSymbolTicker(
     category: UMCategory | '',
-    symbol?: string
+    symbol?: string,
   ): Promise<APIResponseV3<ContractListResult<ContractSymbolTicker>>> {
     return this.get('/derivatives/v3/public/tickers', { category, symbol });
   }
 
   /** Get trading rules per symbol/contract, incl price/amount/value/leverage filters */
   getInstrumentInfo(
-    params: UMInstrumentInfoRequest
+    params: UMInstrumentInfoRequest,
   ): Promise<APIResponseV3<any>> {
     return this.get('/derivatives/v3/public/instruments-info', params);
   }
@@ -98,18 +98,18 @@ export class ContractClient extends BaseRestClient {
    * For example, if a request is sent at 12:00 UTC, the funding rate generated earlier that day at 08:00 UTC will be sent.
    */
   getFundingRateHistory(
-    params: UMFundingRateHistoryRequest
+    params: UMFundingRateHistoryRequest,
   ): Promise<APIResponseV3<any>> {
     return this.get(
       '/derivatives/v3/public/funding/history-funding-rate',
-      params
+      params,
     );
   }
 
   /** Get Risk Limit */
   getRiskLimit(
     category: UMCategory,
-    symbol: string
+    symbol: string,
   ): Promise<APIResponseV3<any>> {
     return this.get('/derivatives/v3/public/risk-limit/list', {
       category,
@@ -119,7 +119,7 @@ export class ContractClient extends BaseRestClient {
 
   /** Get option delivery price */
   getOptionDeliveryPrice(
-    params: UMOptionDeliveryPriceRequest
+    params: UMOptionDeliveryPriceRequest,
   ): Promise<APIResponseV3<any>> {
     return this.get('/derivatives/v3/public/delivery-price', params);
   }
@@ -150,9 +150,14 @@ export class ContractClient extends BaseRestClient {
     return this.postPrivate('/contract/v3/private/order/create', params);
   }
 
-  /** Query order history. As order creation/cancellation is asynchronous, the data returned from the interface may be delayed. To access order information in real-time, call getActiveOrders() */
+  /**
+   * Query order history.
+   *
+   * As order creation/cancellation is asynchronous, the data returned from the interface may be delayed.
+   * To access order information in real-time, call getActiveOrders().
+   */
   getHistoricOrders(
-    params: ContractHistoricOrdersRequest
+    params: ContractHistoricOrdersRequest,
   ): Promise<APIResponseV3<PaginatedResult<ContractHistoricOrder>>> {
     return this.getPrivate('/contract/v3/private/order/list', params);
   }
@@ -169,18 +174,25 @@ export class ContractClient extends BaseRestClient {
     });
   }
 
-  /** Replace order : Active order parameters (such as quantity, price) and stop order parameters cannot be modified in one request at the same time. Please request modification separately. */
+  /**
+   * Replace order
+   *
+   * Active order parameters (such as quantity, price) and stop order parameters
+   * cannot be modified in one request at the same time.
+   *
+   * Please request modification separately.
+   */
   modifyOrder(params: ContractModifyOrderRequest): Promise<APIResponseV3<any>> {
     return this.postPrivate('/contract/v3/private/order/replace', params);
   }
 
   /** Query Open Order(s) (real-time) */
   getActiveOrders(
-    params: ContractActiveOrdersRequest
+    params: ContractActiveOrdersRequest,
   ): Promise<APIResponseV3<any>> {
     return this.getPrivate(
       '/contract/v3/private/order/unfilled-orders',
-      params
+      params,
     );
   }
 
@@ -197,31 +209,31 @@ export class ContractClient extends BaseRestClient {
 
   /** Set auto add margin, or Auto-Margin Replenishment. */
   setAutoAddMargin(
-    params: ContractSetAutoAddMarginRequest
+    params: ContractSetAutoAddMarginRequest,
   ): Promise<APIResponseV3<any>> {
     return this.postPrivate(
       '/contract/v3/private/position/set-auto-add-margin',
-      params
+      params,
     );
   }
 
   /** Switch cross margin mode/isolated margin mode */
   setMarginSwitch(
-    params: ContractSetMarginSwitchRequest
+    params: ContractSetMarginSwitchRequest,
   ): Promise<APIResponseV3<any>> {
     return this.postPrivate(
       '/contract/v3/private/position/switch-isolated',
-      params
+      params,
     );
   }
 
   /** Supports switching between One-Way Mode and Hedge Mode at the coin level. */
   setPositionMode(
-    params: ContractSetPositionModeRequest
+    params: ContractSetPositionModeRequest,
   ): Promise<APIResponseV3<any>> {
     return this.postPrivate(
       '/contract/v3/private/position/switch-mode',
-      params
+      params,
     );
   }
 
@@ -230,7 +242,7 @@ export class ContractClient extends BaseRestClient {
    */
   setTPSLMode(
     symbol: string,
-    tpSlMode: 'Full' | 'Partial'
+    tpSlMode: 'Full' | 'Partial',
   ): Promise<APIResponseV3<any>> {
     return this.postPrivate('/contract/v3/private/position/switch-tpsl-mode', {
       symbol,
@@ -242,7 +254,7 @@ export class ContractClient extends BaseRestClient {
   setLeverage(
     symbol: string,
     buyLeverage: string,
-    sellLeverage: string
+    sellLeverage: string,
   ): Promise<APIResponseV3<any>> {
     return this.postPrivate('/contract/v3/private/position/set-leverage', {
       symbol,
@@ -258,7 +270,7 @@ export class ContractClient extends BaseRestClient {
   setTPSL(params: ContractSetTPSLRequest): Promise<APIResponseV3<any>> {
     return this.postPrivate(
       '/contract/v3/private/position/trading-stop',
-      params
+      params,
     );
   }
 
@@ -267,7 +279,7 @@ export class ContractClient extends BaseRestClient {
     symbol: string,
     riskId: number,
     /** 0-one-way, 1-buy side, 2-sell side */
-    positionIdx: 0 | 1 | 2
+    positionIdx: 0 | 1 | 2,
   ): Promise<APIResponseV3<any>> {
     return this.postPrivate('/contract/v3/private/position/set-risk-limit', {
       symbol,
@@ -281,7 +293,7 @@ export class ContractClient extends BaseRestClient {
    * The results are ordered in descending order (the first item is the latest). Returns records up to 2 years old.
    */
   getUserExecutionHistory(
-    params: ContractUserExecutionHistoryRequest
+    params: ContractUserExecutionHistoryRequest,
   ): Promise<APIResponseV3<any>> {
     return this.getPrivate('/contract/v3/private/execution/list', params);
   }
@@ -291,7 +303,7 @@ export class ContractClient extends BaseRestClient {
    * The results are ordered in descending order (the first item is the latest).
    */
   getClosedProfitAndLoss(
-    params: ContractClosedPNLRequest
+    params: ContractClosedPNLRequest,
   ): Promise<APIResponseV3<any>> {
     return this.getPrivate('/contract/v3/private/position/closed-pnl', params);
   }
@@ -321,16 +333,18 @@ export class ContractClient extends BaseRestClient {
 
   /**
    * Get wallet fund records.
-   * This endpoint also shows exchanges from the Asset Exchange, where the types for the exchange are ExchangeOrderWithdraw and ExchangeOrderDeposit.
+   * This endpoint also shows exchanges from the Asset Exchange,
+   * where the types for the exchange are ExchangeOrderWithdraw and ExchangeOrderDeposit.
+   *
    * This endpoint returns incomplete information for transfers involving the derivatives wallet.
    * Use the account asset API for creating and querying internal transfers.
    */
   getWalletFundRecords(
-    params?: ContractWalletFundRecordRequest
+    params?: ContractWalletFundRecordRequest,
   ): Promise<APIResponseV3<any>> {
     return this.getPrivate(
       '/contract/v3/private/account/wallet/fund-records',
-      params
+      params,
     );
   }
 

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -35,6 +35,7 @@ import {
   CreateSubMemberParamsV5,
   CreateSubMemberResultV5,
   CursorListV5,
+  DeliveryPriceV5,
   DeliveryRecordV5,
   DepositAddressResultV5,
   DepositRecordV5,
@@ -50,6 +51,7 @@ import {
   GetBorrowHistoryParamsV5,
   GetClosedPnLParamsV5,
   GetCoinExchangeRecordParamsV5,
+  GetDeliveryPriceParamsV5,
   GetDeliveryRecordParamsV5,
   GetDepositRecordParamsV5,
   GetExecutionListParamsV5,
@@ -333,12 +335,25 @@ export class RestClientV5 extends BaseRestClient {
    * Get the delivery price for option
    *
    * Covers: Option
+   *
+   * @deprecated use getDeliveryPrice() instead
    */
   getOptionDeliveryPrice(
     params: GetOptionDeliveryPriceParamsV5,
   ): Promise<
     APIResponseV3WithTime<CategoryCursorListV5<OptionDeliveryPriceV5[]>>
   > {
+    return this.get('/v5/market/delivery-price', params);
+  }
+
+  /**
+   * Get the delivery price of Inverse futures, USDC futures and Options
+   *
+   * Covers: USDC futures / Inverse futures / Option
+   */
+  getDeliveryPrice(
+    params: GetDeliveryPriceParamsV5,
+  ): Promise<APIResponseV3WithTime<CategoryCursorListV5<DeliveryPriceV5[]>>> {
     return this.get('/v5/market/delivery-price', params);
   }
 

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -42,6 +42,7 @@ import {
   FeeRateV5,
   FundingRateHistoryResponseV5,
   GetAccountCoinBalanceParamsV5,
+  GetAccountHistoricOrdersPArams,
   GetAccountOrdersParams,
   GetAllCoinsBalanceParamsV5,
   GetAllowedDepositCoinInfoParamsV5,
@@ -162,7 +163,7 @@ export class RestClientV5 extends BaseRestClient {
    * Covers: Spot / Linear contract / Inverse contract
    */
   getKline(
-    params: GetKlineParamsV5
+    params: GetKlineParamsV5,
   ): Promise<
     APIResponseV3WithTime<
       CategorySymbolListV5<OHLCVKlineV5[], 'spot' | 'linear' | 'inverse'>
@@ -177,7 +178,7 @@ export class RestClientV5 extends BaseRestClient {
    * Covers: Linear contract / Inverse contract
    */
   getMarkPriceKline(
-    params: GetMarkPriceKlineParamsV5
+    params: GetMarkPriceKlineParamsV5,
   ): Promise<
     APIResponseV3WithTime<
       CategorySymbolListV5<OHLCKlineV5[], 'linear' | 'inverse'>
@@ -192,7 +193,7 @@ export class RestClientV5 extends BaseRestClient {
    * Covers: Linear contract / Inverse contract
    */
   getIndexPriceKline(
-    params: GetIndexPriceKlineParamsV5
+    params: GetIndexPriceKlineParamsV5,
   ): Promise<
     APIResponseV3WithTime<
       CategorySymbolListV5<OHLCKlineV5[], 'linear' | 'inverse'>
@@ -207,7 +208,7 @@ export class RestClientV5 extends BaseRestClient {
    * Covers: Linear contract
    */
   getPremiumIndexPriceKline(
-    params: GetPremiumIndexPriceKlineParamsV5
+    params: GetPremiumIndexPriceKlineParamsV5,
   ): Promise<
     APIResponseV3WithTime<CategorySymbolListV5<OHLCKlineV5[], 'linear'>>
   > {
@@ -222,7 +223,7 @@ export class RestClientV5 extends BaseRestClient {
    * Note: Spot does not support pagination, so limit & cursor are invalid.
    */
   getInstrumentsInfo(
-    params: GetInstrumentsInfoParamsV5
+    params: GetInstrumentsInfoParamsV5,
   ): Promise<APIResponseV3WithTime<InstrumentInfoResponseV5>> {
     return this.get('/v5/market/instruments-info', params);
   }
@@ -233,7 +234,7 @@ export class RestClientV5 extends BaseRestClient {
    * Covers: Spot / Linear contract / Inverse contract / Option
    */
   getOrderbook(
-    params: GetOrderbookParamsV5
+    params: GetOrderbookParamsV5,
   ): Promise<APIResponseV3WithTime<OrderbookResponseV5>> {
     return this.get('/v5/market/orderbook', params);
   }
@@ -244,7 +245,7 @@ export class RestClientV5 extends BaseRestClient {
    * Covers: Spot / Linear contract / Inverse contract / Option
    */
   getTickers(
-    params: GetTickersParamsV5
+    params: GetTickersParamsV5,
   ): Promise<
     APIResponseV3WithTime<
       | CategoryListV5<TickerLinearInverseV5[], 'linear' | 'inverse'>
@@ -261,7 +262,7 @@ export class RestClientV5 extends BaseRestClient {
    * Covers: Linear contract / Inverse perpetual
    */
   getFundingRateHistory(
-    params: GetFundingRateHistoryParamsV5
+    params: GetFundingRateHistoryParamsV5,
   ): Promise<
     APIResponseV3WithTime<
       CategoryListV5<FundingRateHistoryResponseV5[], 'linear' | 'inverse'>
@@ -276,7 +277,7 @@ export class RestClientV5 extends BaseRestClient {
    * Covers: Spot / Linear contract / Inverse contract / Option
    */
   getPublicTradingHistory(
-    params: GetPublicTradingHistoryParamsV5
+    params: GetPublicTradingHistoryParamsV5,
   ): Promise<
     APIResponseV3WithTime<CategoryListV5<PublicTradeV5[], CategoryV5>>
   > {
@@ -289,7 +290,7 @@ export class RestClientV5 extends BaseRestClient {
    * Covers: Linear contract / Inverse contract
    */
   getOpenInterest(
-    params: GetOpenInterestParamsV5
+    params: GetOpenInterestParamsV5,
   ): Promise<APIResponseV3WithTime<OpenInterestResponseV5>> {
     return this.get('/v5/market/open-interest', params);
   }
@@ -299,7 +300,7 @@ export class RestClientV5 extends BaseRestClient {
    * Covers: Option
    */
   getHistoricalVolatility(
-    params: GetHistoricalVolatilityParamsV5
+    params: GetHistoricalVolatilityParamsV5,
   ): Promise<
     APIResponseV3WithTime<CategoryListV5<HistoricalVolatilityV5[], 'option'>>
   > {
@@ -310,7 +311,7 @@ export class RestClientV5 extends BaseRestClient {
    * Query Bybit insurance pool data (BTC/USDT/USDC etc). The data is updated every 24 hours.
    */
   getInsurance(
-    params?: GetInsuranceParamsV5
+    params?: GetInsuranceParamsV5,
   ): Promise<APIResponseV3WithTime<InsuranceResponseV5>> {
     return this.get('/v5/market/insurance', params);
   }
@@ -321,7 +322,7 @@ export class RestClientV5 extends BaseRestClient {
    * Covers: Linear contract / Inverse contract
    */
   getRiskLimit(
-    params?: GetRiskLimitParamsV5
+    params?: GetRiskLimitParamsV5,
   ): Promise<
     APIResponseV3WithTime<CategoryListV5<RiskLimitV5[], 'inverse' | 'linear'>>
   > {
@@ -334,7 +335,7 @@ export class RestClientV5 extends BaseRestClient {
    * Covers: Option
    */
   getOptionDeliveryPrice(
-    params: GetOptionDeliveryPriceParamsV5
+    params: GetOptionDeliveryPriceParamsV5,
   ): Promise<
     APIResponseV3WithTime<CategoryCursorListV5<OptionDeliveryPriceV5[]>>
   > {
@@ -348,19 +349,19 @@ export class RestClientV5 extends BaseRestClient {
    */
 
   submitOrder(
-    params: OrderParamsV5
+    params: OrderParamsV5,
   ): Promise<APIResponseV3WithTime<OrderResultV5>> {
     return this.postPrivate('/v5/order/create', params);
   }
 
   amendOrder(
-    params: AmendOrderParamsV5
+    params: AmendOrderParamsV5,
   ): Promise<APIResponseV3WithTime<OrderResultV5>> {
     return this.postPrivate('/v5/order/amend', params);
   }
 
   cancelOrder(
-    params: CancelOrderParamsV5
+    params: CancelOrderParamsV5,
   ): Promise<APIResponseV3WithTime<OrderResultV5>> {
     return this.postPrivate('/v5/order/cancel', params);
   }
@@ -369,13 +370,13 @@ export class RestClientV5 extends BaseRestClient {
    * Query unfilled or partially filled orders in real-time. To query older order records, please use the order history interface.
    */
   getActiveOrders(
-    params: GetAccountOrdersParams
+    params: GetAccountOrdersParams,
   ): Promise<APIResponseV3WithTime<CategoryCursorListV5<AccountOrderV5[]>>> {
     return this.getPrivate('/v5/order/realtime', params);
   }
 
   cancelAllOrders(
-    params: CancelAllOrdersParamsV5
+    params: CancelAllOrdersParamsV5,
   ): Promise<APIResponseV3WithTime<{ list: OrderResultV5[] }>> {
     return this.postPrivate('/v5/order/cancel-all', params);
   }
@@ -386,7 +387,7 @@ export class RestClientV5 extends BaseRestClient {
    * If you want to get real-time order information, you could query this endpoint or rely on the websocket stream (recommended).
    */
   getHistoricOrders(
-    params: GetAccountOrdersParams
+    params: GetAccountHistoricOrdersPArams,
   ): Promise<APIResponseV3WithTime<CategoryCursorListV5<AccountOrderV5[]>>> {
     return this.getPrivate('/v5/order/history', params);
   }
@@ -404,7 +405,7 @@ export class RestClientV5 extends BaseRestClient {
    */
   batchSubmitOrders(
     category: 'option',
-    orders: BatchOrderParamsV5[]
+    orders: BatchOrderParamsV5[],
   ): Promise<
     APIResponseV3WithTime<BatchOrdersResponseV5<BatchCreateOrderResultV5[]>>
   > {
@@ -423,7 +424,7 @@ export class RestClientV5 extends BaseRestClient {
    */
   batchAmendOrders(
     category: 'option',
-    orders: BatchAmendOrderParamsV5[]
+    orders: BatchAmendOrderParamsV5[],
   ): Promise<
     APIResponseV3WithTime<BatchOrdersResponseV5<BatchAmendOrderResultV5[]>>
   > {
@@ -442,7 +443,7 @@ export class RestClientV5 extends BaseRestClient {
    */
   batchCancelOrders(
     category: 'option',
-    orders: BatchCancelOrderParamsV5[]
+    orders: BatchCancelOrderParamsV5[],
   ): Promise<
     APIResponseV3WithTime<BatchOrdersResponseV5<BatchCancelOrderResultV5[]>>
   > {
@@ -459,7 +460,7 @@ export class RestClientV5 extends BaseRestClient {
    */
   getSpotBorrowCheck(
     symbol: string,
-    side: OrderSideV5
+    side: OrderSideV5,
   ): Promise<APIResponseV3WithTime<SpotBorrowCheckResultV5>> {
     return this.getPrivate('/v5/order/spot-borrow-check', {
       category: 'spot',
@@ -476,7 +477,7 @@ export class RestClientV5 extends BaseRestClient {
    */
   setDisconnectCancelAllWindow(
     category: 'option',
-    timeWindow: number
+    timeWindow: number,
   ): Promise<APIResponseV3<undefined>> {
     return this.postPrivate('/v5/order/disconnected-cancel-all', {
       category,
@@ -502,7 +503,7 @@ export class RestClientV5 extends BaseRestClient {
    * Note: this will give a 404 error if you query the `option` category if your account is not unified
    */
   getPositionInfo(
-    params: PositionInfoParamsV5
+    params: PositionInfoParamsV5,
   ): Promise<APIResponseV3WithTime<CategoryCursorListV5<PositionV5[]>>> {
     return this.getPrivate('/v5/position/list', params);
   }
@@ -530,7 +531,7 @@ export class RestClientV5 extends BaseRestClient {
    * Please make sure that there are no open orders before you switch margin modes.
    */
   switchIsolatedMargin(
-    params: SwitchIsolatedMarginParamsV5
+    params: SwitchIsolatedMarginParamsV5,
   ): Promise<APIResponseV3WithTime<{}>> {
     return this.postPrivate('/v5/position/switch-isolated', params);
   }
@@ -543,7 +544,7 @@ export class RestClientV5 extends BaseRestClient {
    * For partial TP/SL mode, you can set the TP/SL size smaller than position size.
    */
   setTPSLMode(
-    params: SetTPSLModeParamsV5
+    params: SetTPSLModeParamsV5,
   ): Promise<APIResponseV3WithTime<{ tpSlMode: TPSLModeV5 }>> {
     return this.postPrivate('/v5/position/set-tpsl-mode', params);
   }
@@ -558,7 +559,7 @@ export class RestClientV5 extends BaseRestClient {
    * Position mode. 0: Merged Single. 3: Both Sides.
    */
   switchPositionMode(
-    params: SwitchPositionModeParamsV5
+    params: SwitchPositionModeParamsV5,
   ): Promise<APIResponseV3WithTime<{}>> {
     return this.postPrivate('/v5/position/switch-mode', params);
   }
@@ -571,7 +572,7 @@ export class RestClientV5 extends BaseRestClient {
    * If the order exceeds the current risk limit when placing an order, it will be rejected.
    */
   setRiskLimit(
-    params: SetRiskLimitParamsV5
+    params: SetRiskLimitParamsV5,
   ): Promise<APIResponseV3WithTime<SetRiskLimitResultV5>> {
     return this.postPrivate('/v5/position/set-risk-limit', params);
   }
@@ -586,7 +587,7 @@ export class RestClientV5 extends BaseRestClient {
    * Normal account covers: USDT perpetual / Inverse perpetual / Inverse futures.
    */
   setTradingStop(
-    params: SetTradingStopParamsV5
+    params: SetTradingStopParamsV5,
   ): Promise<APIResponseV3WithTime<{}>> {
     return this.postPrivate('/v5/position/trading-stop', params);
   }
@@ -597,7 +598,7 @@ export class RestClientV5 extends BaseRestClient {
    * Covers: USDT perpetual (Normal Account).
    */
   setAutoAddMargin(
-    params: SetAutoAddMarginParamsV5
+    params: SetAutoAddMarginParamsV5,
   ): Promise<APIResponseV3WithTime<{}>> {
     return this.postPrivate('/v5/position/set-auto-add-margin', params);
   }
@@ -609,7 +610,7 @@ export class RestClientV5 extends BaseRestClient {
    * Normal account covers: USDT perpetual / Inverse perpetual / Inverse futures
    */
   getExecutionList(
-    params: GetExecutionListParamsV5
+    params: GetExecutionListParamsV5,
   ): Promise<APIResponseV3WithTime<CategoryCursorListV5<ExecutionV5[]>>> {
     return this.getPrivate('/v5/execution/list', params);
   }
@@ -621,7 +622,7 @@ export class RestClientV5 extends BaseRestClient {
    * Normal account covers: USDT perpetual / Inverse perpetual / Inverse futures
    */
   getClosedPnL(
-    params: GetClosedPnLParamsV5
+    params: GetClosedPnLParamsV5,
   ): Promise<APIResponseV3WithTime<CategoryCursorListV5<ClosedPnLV5[]>>> {
     return this.getPrivate('/v5/position/closed-pnl', params);
   }
@@ -638,7 +639,7 @@ export class RestClientV5 extends BaseRestClient {
    * By default, currency information with assets or liabilities of 0 is not returned.
    */
   getWalletBalance(
-    params: GetWalletBalanceParamsV5
+    params: GetWalletBalanceParamsV5,
   ): Promise<APIResponseV3WithTime<{ list: WalletBalanceV5[] }>> {
     return this.getPrivate('/v5/account/wallet-balance', params);
   }
@@ -660,7 +661,7 @@ export class RestClientV5 extends BaseRestClient {
    * Unified account
    */
   getBorrowHistory(
-    params?: GetBorrowHistoryParamsV5
+    params?: GetBorrowHistoryParamsV5,
   ): Promise<APIResponseV3WithTime<CursorListV5<BorrowHistoryRecordV5[]>>> {
     return this.getPrivate('/v5/account/borrow-history', params);
   }
@@ -670,7 +671,7 @@ export class RestClientV5 extends BaseRestClient {
    * loanable amount, collateral conversion rate, whether it can be mortgaged as margin, etc.
    */
   getCollateralInfo(
-    currency?: string
+    currency?: string,
   ): Promise<APIResponseV3WithTime<{ list: CollateralInfoV5[] }>> {
     return this.getPrivate('/v5/account/collateral-info', { currency });
   }
@@ -679,11 +680,11 @@ export class RestClientV5 extends BaseRestClient {
    * Get current account Greeks information
    */
   getCoinGreeks(
-    baseCoin?: string
+    baseCoin?: string,
   ): Promise<APIResponseV3WithTime<{ list: CoinGreeksV5[] }>> {
     return this.getPrivate(
       '/v5/asset/coin-greeks',
-      baseCoin ? { baseCoin } : undefined
+      baseCoin ? { baseCoin } : undefined,
     );
   }
 
@@ -692,11 +693,11 @@ export class RestClientV5 extends BaseRestClient {
    * Covers: USDT perpetual / Inverse perpetual / Inverse futures
    */
   getFeeRate(
-    symbol?: string
+    symbol?: string,
   ): Promise<APIResponseV3WithTime<{ list: FeeRateV5[] }>> {
     return this.getPrivate(
       '/v5/account/fee-rate',
-      symbol ? { symbol } : undefined
+      symbol ? { symbol } : undefined,
     );
   }
 
@@ -711,7 +712,7 @@ export class RestClientV5 extends BaseRestClient {
    * Query transaction logs in Unified account.
    */
   getTransactionLog(
-    params?: GetTransactionLogParamsV5
+    params?: GetTransactionLogParamsV5,
   ): Promise<APIResponseV3WithTime<CursorListV5<TransactionLogV5[]>>> {
     return this.getPrivate('/v5/account/transaction-log', params);
   }
@@ -722,7 +723,7 @@ export class RestClientV5 extends BaseRestClient {
    * This mode is valid for USDT Perp, USDC Perp and USDC Option.
    */
   setMarginMode(
-    marginMode: AccountMarginModeV5
+    marginMode: AccountMarginModeV5,
   ): Promise<
     APIResponseV3<{ reasons: { reasonCode: string; reasonMsg: string }[] }>
   > {
@@ -749,7 +750,7 @@ export class RestClientV5 extends BaseRestClient {
    * Get MMP State
    */
   getMMPState(
-    baseCoin: string
+    baseCoin: string,
   ): Promise<APIResponseV3WithTime<{ result: MMPStateV5[] }>> {
     return this.getPrivate('/v5/account/mmp-state', { baseCoin });
   }
@@ -780,7 +781,7 @@ export class RestClientV5 extends BaseRestClient {
    * Covers: Option
    */
   getDeliveryRecord(
-    params: GetDeliveryRecordParamsV5
+    params: GetDeliveryRecordParamsV5,
   ): Promise<APIResponseV3WithTime<CategoryCursorListV5<DeliveryRecordV5[]>>> {
     return this.getPrivate('/v5/asset/delivery-record', params);
   }
@@ -791,7 +792,7 @@ export class RestClientV5 extends BaseRestClient {
    * Covers: Linear contract (USDC Perpetual only, Unified Account)
    */
   getSettlementRecords(
-    params: GetSettlementRecordParamsV5
+    params: GetSettlementRecordParamsV5,
   ): Promise<
     APIResponseV3WithTime<CategoryCursorListV5<SettlementRecordV5[]>>
   > {
@@ -805,7 +806,7 @@ export class RestClientV5 extends BaseRestClient {
    * For now, it can query SPOT only.
    */
   getAssetInfo(
-    params: GetAssetInfoParamsV5
+    params: GetAssetInfoParamsV5,
   ): Promise<APIResponseV3WithTime<{ spot: AssetInfoV5 }>> {
     return this.getPrivate('/v5/asset/transfer/query-asset-info', params);
   }
@@ -816,11 +817,11 @@ export class RestClientV5 extends BaseRestClient {
    * It is not allowed to get the master account coin balance via sub account API key.
    */
   getAllCoinsBalance(
-    params: GetAllCoinsBalanceParamsV5
+    params: GetAllCoinsBalanceParamsV5,
   ): Promise<APIResponseV3WithTime<AllCoinsBalanceV5>> {
     return this.getPrivate(
       '/v5/asset/transfer/query-account-coins-balance',
-      params
+      params,
     );
   }
 
@@ -830,11 +831,11 @@ export class RestClientV5 extends BaseRestClient {
    * CAUTION: Can query by the master UID's api key only.
    */
   getCoinBalance(
-    params: GetAccountCoinBalanceParamsV5
+    params: GetAccountCoinBalanceParamsV5,
   ): Promise<APIResponseV3<AccountCoinBalanceV5>> {
     return this.getPrivate(
       '/v5/asset/transfer/query-account-coin-balance',
-      params
+      params,
     );
   }
 
@@ -843,7 +844,7 @@ export class RestClientV5 extends BaseRestClient {
    */
   getTransferableCoinList(
     fromAccountType: AccountTypeV5,
-    toAccountType: AccountTypeV5
+    toAccountType: AccountTypeV5,
   ): Promise<APIResponseV3WithTime<{ list: string[] }>> {
     return this.getPrivate('/v5/asset/transfer/query-transfer-coin-list', {
       fromAccountType,
@@ -862,7 +863,7 @@ export class RestClientV5 extends BaseRestClient {
     coin: string,
     amount: string,
     fromAccountType: AccountTypeV5,
-    toAccountType: AccountTypeV5
+    toAccountType: AccountTypeV5,
   ): Promise<APIResponseV3WithTime<{ transferId: string }>> {
     return this.postPrivate('/v5/asset/transfer/inter-transfer', {
       transferId,
@@ -877,11 +878,11 @@ export class RestClientV5 extends BaseRestClient {
    * Query the internal transfer records between different account types under the same UID.
    */
   getInternalTransferRecords(
-    params?: GetInternalTransferParamsV5
+    params?: GetInternalTransferParamsV5,
   ): Promise<APIResponseV3WithTime<CursorListV5<InternalTransferRecordV5[]>>> {
     return this.getPrivate(
       '/v5/asset/transfer/query-inter-transfer-list',
-      params
+      params,
     );
   }
 
@@ -907,7 +908,7 @@ export class RestClientV5 extends BaseRestClient {
    * If not set, your subaccount cannot use universal transfers.
    */
   enableUniversalTransferForSubUIDs(
-    subMemberIds: string[]
+    subMemberIds: string[],
   ): Promise<APIResponseV3WithTime<{}>> {
     return this.postPrivate('/v5/asset/transfer/save-transfer-sub-member', {
       subMemberIds,
@@ -918,7 +919,7 @@ export class RestClientV5 extends BaseRestClient {
    * Transfer between sub-sub or main-sub. Please make sure you have enabled universal transfer on your sub UID in advance.
    */
   createUniversalTransfer(
-    params: UniversalTransferParamsV5
+    params: UniversalTransferParamsV5,
   ): Promise<APIResponseV3WithTime<{ transferId: string }>> {
     return this.postPrivate('/v5/asset/transfer/universal-transfer', params);
   }
@@ -930,11 +931,11 @@ export class RestClientV5 extends BaseRestClient {
    * Can query by the master UID's API key only
    */
   getUniversalTransferRecords(
-    params?: GetUniversalTransferRecordsParamsV5
+    params?: GetUniversalTransferRecordsParamsV5,
   ): Promise<APIResponseV3WithTime<CursorListV5<UniversalTransferRecordV5[]>>> {
     return this.getPrivate(
       '/v5/asset/transfer/query-universal-transfer-list',
-      params
+      params,
     );
   }
 
@@ -943,7 +944,7 @@ export class RestClientV5 extends BaseRestClient {
    * To find out paired chain of coin, please refer to the coin info api.
    */
   getAllowedDepositCoinInfo(
-    params?: GetAllowedDepositCoinInfoParamsV5
+    params?: GetAllowedDepositCoinInfoParamsV5,
   ): Promise<
     APIResponseV3WithTime<{
       configList: AllowedDepositCoinInfoV5[];
@@ -962,7 +963,7 @@ export class RestClientV5 extends BaseRestClient {
    * Can use main or sub UID api key to query deposit records respectively.
    */
   getDepositRecords(
-    params?: GetDepositRecordParamsV5
+    params?: GetDepositRecordParamsV5,
   ): Promise<
     APIResponseV3WithTime<{ rows: DepositRecordV5[]; nextPageCursor: string }>
   > {
@@ -977,7 +978,7 @@ export class RestClientV5 extends BaseRestClient {
    *      Queries for the last 30 days worth of records by default.
    */
   getSubAccountDepositRecords(
-    params: GetSubAccountDepositRecordParamsV5
+    params: GetSubAccountDepositRecordParamsV5,
   ): Promise<
     APIResponseV3WithTime<{ rows: DepositRecordV5[]; nextPageCursor: string }>
   > {
@@ -1006,7 +1007,7 @@ export class RestClientV5 extends BaseRestClient {
    */
   getMasterDepositAddress(
     coin: string,
-    chainType?: string
+    chainType?: string,
   ): Promise<APIResponseV3WithTime<DepositAddressResultV5>> {
     return this.getPrivate('/v5/asset/deposit/query-address', {
       coin,
@@ -1023,7 +1024,7 @@ export class RestClientV5 extends BaseRestClient {
   querySubMemberAddress(
     coin: string,
     chainType: string,
-    subMemberId: string
+    subMemberId: string,
   ): Promise<APIResponseV3<DepositAddressResultV5>> {
     return this.getPrivate('/v5/asset/deposit/query-sub-member-address', {
       coin,
@@ -1036,11 +1037,11 @@ export class RestClientV5 extends BaseRestClient {
    * Query coin information, including chain information, withdraw and deposit status.
    */
   getCoinInfo(
-    coin?: string
+    coin?: string,
   ): Promise<APIResponseV3WithTime<{ rows: CoinInfoV5[] }>> {
     return this.getPrivate(
       '/v5/asset/coin/query-info',
-      coin ? { coin } : undefined
+      coin ? { coin } : undefined,
     );
   }
 
@@ -1048,7 +1049,7 @@ export class RestClientV5 extends BaseRestClient {
    * Query withdrawal records.
    */
   getWithdrawalRecords(
-    params?: GetWithdrawalRecordsParamsV5
+    params?: GetWithdrawalRecordsParamsV5,
   ): Promise<APIResponseV3<{ rows: WithdrawalRecordV5[] }>> {
     return this.getPrivate('/v5/asset/withdraw/query-record', params);
   }
@@ -1061,7 +1062,7 @@ export class RestClientV5 extends BaseRestClient {
    * You can make an off-chain transfer if the target wallet address is from Bybit. This means that no blockchain fee will be charged.
    */
   submitWithdrawal(
-    params: WithdrawParamsV5
+    params: WithdrawParamsV5,
   ): Promise<APIResponseV3WithTime<{ id: string }>> {
     return this.postPrivate('/v5/asset/withdraw/create', params);
   }
@@ -1072,7 +1073,7 @@ export class RestClientV5 extends BaseRestClient {
    * CAUTION: Can query by the master UID's api key only
    */
   cancelWithdrawal(
-    id: string
+    id: string,
   ): Promise<APIResponseV3WithTime<{ status: 0 | 1 }>> {
     return this.postPrivate('/v5/asset/withdraw/cancel', { id });
   }
@@ -1091,7 +1092,7 @@ export class RestClientV5 extends BaseRestClient {
    * master API key: "Account Transfer", "Subaccount Transfer", "Withdrawal"
    */
   createSubMember(
-    params: CreateSubMemberParamsV5
+    params: CreateSubMemberParamsV5,
   ): Promise<APIResponseV3WithTime<CreateSubMemberResultV5>> {
     return this.postPrivate('/v5/user/create-sub-member', params);
   }
@@ -1104,7 +1105,7 @@ export class RestClientV5 extends BaseRestClient {
    * master API key: "Account Transfer", "Subaccount Transfer", "Withdrawal"
    */
   createSubUIDAPIKey(
-    params: CreateSubApiKeyParamsV5
+    params: CreateSubApiKeyParamsV5,
   ): Promise<APIResponseV3WithTime<CreateSubApiKeyResultV5>> {
     return this.postPrivate('/v5/user/create-sub-api', params);
   }
@@ -1127,7 +1128,7 @@ export class RestClientV5 extends BaseRestClient {
    */
   setSubUIDFrozenState(
     subuid: number,
-    frozen: 0 | 1
+    frozen: 0 | 1,
   ): Promise<APIResponseV3WithTime<{}>> {
     return this.postPrivate('/v5/user/frozen-sub-member', { subuid, frozen });
   }
@@ -1150,7 +1151,7 @@ export class RestClientV5 extends BaseRestClient {
    * Master API key: "Account Transfer", "Subaccount Transfer", "Withdrawal"
    */
   updateMasterApiKey(
-    params: UpdateApiKeyParamsV5
+    params: UpdateApiKeyParamsV5,
   ): Promise<APIResponseV3WithTime<UpdateApiKeyResultV5>> {
     return this.postPrivate('/v5/user/update-api', params);
   }
@@ -1163,7 +1164,7 @@ export class RestClientV5 extends BaseRestClient {
    * The API key must own "Account Transfer" permission to be allowed to call this API endpoint.
    */
   updateSubApiKey(
-    params: UpdateApiKeyParamsV5
+    params: UpdateApiKeyParamsV5,
   ): Promise<APIResponseV3<UpdateApiKeyResultV5>> {
     return this.postPrivate('/v5/user/update-sub-api', params);
   }
@@ -1203,7 +1204,7 @@ export class RestClientV5 extends BaseRestClient {
    * Query leverage token information
    */
   getLeveragedTokenInfo(
-    ltCoin?: string
+    ltCoin?: string,
   ): Promise<APIResponseV3WithTime<{ list: LeverageTokenInfoV5[] }>> {
     return this.get('/v5/spot-lever-token/info', { ltCoin });
   }
@@ -1212,7 +1213,7 @@ export class RestClientV5 extends BaseRestClient {
    * Get leverage token market information.
    */
   getLeveragedTokenMarket(
-    ltCoin: string
+    ltCoin: string,
   ): Promise<APIResponseV3WithTime<LeveragedTokenMarketResultV5>> {
     return this.get('/v5/spot-lever-token/reference', { ltCoin });
   }
@@ -1221,7 +1222,7 @@ export class RestClientV5 extends BaseRestClient {
    * This endpoint allows you to purchase a leveraged token with a specified amount.
    */
   purchaseSpotLeveragedToken(
-    params: PurchaseSpotLeveragedTokenParamsV5
+    params: PurchaseSpotLeveragedTokenParamsV5,
   ): Promise<APIResponseV3WithTime<PurchaseSpotLeveragedTokenResultV5>> {
     return this.postPrivate('/v5/spot-lever-token/purchase', params);
   }
@@ -1230,7 +1231,7 @@ export class RestClientV5 extends BaseRestClient {
    * Redeem leveraged token.
    */
   redeemSpotLeveragedToken(
-    params: RedeemSpotLeveragedTokenParamsV5
+    params: RedeemSpotLeveragedTokenParamsV5,
   ): Promise<APIResponseV3WithTime<RedeemSpotLeveragedTokenResultV5>> {
     return this.postPrivate('/v5/spot-lever-token/redeem', params);
   }
@@ -1239,7 +1240,7 @@ export class RestClientV5 extends BaseRestClient {
    * Get purchase or redemption history
    */
   getSpotLeveragedTokenOrderHistory(
-    params?: GetSpotLeveragedTokenOrderHistoryParamsV5
+    params?: GetSpotLeveragedTokenOrderHistoryParamsV5,
   ): Promise<
     APIResponseV3WithTime<{ list: SpotLeveragedTokenOrderHistoryV5[] }>
   > {
@@ -1259,7 +1260,7 @@ export class RestClientV5 extends BaseRestClient {
    * Your account needs to turn on spot margin first
    */
   toggleSpotMarginTrade(
-    spotMarginMode: '1' | '0'
+    spotMarginMode: '1' | '0',
   ): Promise<APIResponseV3WithTime<{ spotMarginMode: '1' | '0' }>> {
     return this.postPrivate('/v5/spot-margin-trade/switch-mode', {
       spotMarginMode,

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -57,6 +57,7 @@ import {
   GetDeliveryRecordParamsV5,
   GetDepositRecordParamsV5,
   GetExecutionListParamsV5,
+  GetFeeRateParamsV5,
   GetFundingRateHistoryParamsV5,
   GetHistoricalVolatilityParamsV5,
   GetIndexPriceKlineParamsV5,
@@ -767,16 +768,13 @@ export class RestClientV5 extends BaseRestClient {
   }
 
   /**
-   * Get the trading fee rate of derivatives.
-   * Covers: USDT perpetual / Inverse perpetual / Inverse futures
+   * Get the trading fee rate.
+   * Covers: Spot / USDT perpetual / Inverse perpetual / Inverse futures / Options
    */
   getFeeRate(
-    symbol?: string,
-  ): Promise<APIResponseV3WithTime<{ list: FeeRateV5[] }>> {
-    return this.getPrivate(
-      '/v5/account/fee-rate',
-      symbol ? { symbol } : undefined,
-    );
+    params: GetFeeRateParamsV5,
+  ): Promise<APIResponseV3WithTime<CategoryCursorListV5<FeeRateV5[]>>> {
+    return this.getPrivate('/v5/account/fee-rate', params);
   }
 
   /**

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -6,6 +6,8 @@ import {
   AccountMarginModeV5,
   AccountOrderV5,
   AccountTypeV5,
+  AddOrReduceMarginParamsV5,
+  AddOrReduceMarginResultV5,
   AllCoinsBalanceV5,
   AllowedDepositCoinInfoV5,
   AmendOrderParamsV5,
@@ -616,6 +618,18 @@ export class RestClientV5 extends BaseRestClient {
     params: SetAutoAddMarginParamsV5,
   ): Promise<APIResponseV3WithTime<{}>> {
     return this.postPrivate('/v5/position/set-auto-add-margin', params);
+  }
+
+  /**
+   * Manually add or reduce margin for isolated margin position
+   *
+   * Unified account covers: USDT perpetual / USDC perpetual / USDC futures / Inverse contract
+   * Normal account covers: USDT perpetual / Inverse contract
+   */
+  addOrReduceMargin(
+    params: AddOrReduceMarginParamsV5,
+  ): Promise<APIResponseV3WithTime<AddOrReduceMarginResultV5>> {
+    return this.postPrivate('/v5/position/add-margin', params);
   }
 
   /**

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -69,6 +69,9 @@ import {
   GetOpenInterestParamsV5,
   GetOptionDeliveryPriceParamsV5,
   GetOrderbookParamsV5,
+  GetPreUpgradeClosedPnlParamsV5,
+  GetPreUpgradeOrderHistoryParamsV5,
+  GetPreUpgradeTradeHistoryParamsV5,
   GetPremiumIndexPriceKlineParamsV5,
   GetPublicTradingHistoryParamsV5,
   GetRiskLimitParamsV5,
@@ -654,6 +657,52 @@ export class RestClientV5 extends BaseRestClient {
     params: GetClosedPnLParamsV5,
   ): Promise<APIResponseV3WithTime<CategoryCursorListV5<ClosedPnLV5[]>>> {
     return this.getPrivate('/v5/position/closed-pnl', params);
+  }
+
+  /**
+   *
+   ****** Pre-upgrade APIs
+   *
+   */
+
+  /**
+   * Get those orders which occurred before you upgrade the account to Unified account.
+   *
+   * For now, it only supports to query USDT perpetual, USDC perpetual, Inverse perpetual and futures.
+   *
+   *   - can get all status in 7 days
+   *   - can only get filled orders beyond 7 days
+   */
+  getPreUpgradeOrderHistory(
+    params: GetPreUpgradeOrderHistoryParamsV5,
+  ): Promise<APIResponseV3WithTime<CategoryCursorListV5<AccountOrderV5[]>>> {
+    return this.getPrivate('/v5/pre-upgrade/order/history', params);
+  }
+
+  /**
+   * Get users' execution records which occurred before you upgrade the account to Unified account, sorted by execTime in descending order
+   *
+   * For now, it only supports to query USDT perpetual, Inverse perpetual and futures.
+   *
+   *   - You may have multiple executions in a single order.
+   *   - You can query by symbol, baseCoin, orderId and orderLinkId, and if you pass multiple params,
+   *      the system will process them according to this priority: orderId > orderLinkId > symbol > baseCoin.
+   */
+  getPreUpgradeTradeHistory(
+    params: GetPreUpgradeTradeHistoryParamsV5,
+  ): Promise<APIResponseV3WithTime<CategoryCursorListV5<ExecutionV5[]>>> {
+    return this.getPrivate('/v5/pre-upgrade/execution/list', params);
+  }
+
+  /**
+   * Query user's closed profit and loss records. The results are sorted by createdTime in descending order.
+   *
+   * For now, it only supports to query USDT perpetual, Inverse perpetual and futures.
+   */
+  getPreUpgradeClosedPnl(
+    params: GetPreUpgradeClosedPnlParamsV5,
+  ): Promise<APIResponseV3WithTime<CategoryCursorListV5<ClosedPnLV5[]>>> {
+    return this.getPrivate('/v5/pre-upgrade/position/closed-pnl', params);
   }
 
   /**

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   APIResponseV3,
   APIResponseV3WithTime,
@@ -1360,15 +1361,15 @@ export class RestClientV5 extends BaseRestClient {
 
   /**
    *
-   ****** Spot Margin Trade APIs
+   ****** Spot Margin Trade APIs (UTA)
    *
    */
 
   /**
-   * Turn spot margin trade on / off.
+   * Turn spot margin trade on / off in your UTA account.
    *
    * CAUTION
-   * Your account needs to turn on spot margin first
+   * Your account needs to turn on spot margin first.
    */
   toggleSpotMarginTrade(
     spotMarginMode: '1' | '0',
@@ -1384,5 +1385,254 @@ export class RestClientV5 extends BaseRestClient {
    */
   setSpotMarginLeverage(leverage: string): Promise<APIResponseV3WithTime<{}>> {
     return this.postPrivate('/v5/spot-margin-trade/set-leverage', { leverage });
+  }
+
+  /**
+   *
+   ****** Spot Margin Trade APIs (Normal)
+   *
+   */
+
+  /**
+   * Get Margin Coin Info
+   */
+  getSpotMarginCoinInfo(coin?: string): Promise<
+    APIResponseV3WithTime<{
+      list: {
+        coin: string;
+        conversionRate: string;
+        liquidationOrder: number;
+      }[];
+    }>
+  > {
+    return this.getPrivate('/v5/spot-cross-margin-trade/pledge-token', {
+      coin,
+    });
+  }
+
+  /**
+   * Get Borrowable Coin Info
+   */
+  getSpotMarginBorrowableCoinInfo(coin?: string): Promise<
+    APIResponseV3WithTime<{
+      list: {
+        coin: string;
+        borrowingPrecision: number;
+        repaymentPrecision: number;
+      }[];
+    }>
+  > {
+    return this.getPrivate('/v5/spot-cross-margin-trade/borrow-token', {
+      coin,
+    });
+  }
+
+  /**
+   * Get Interest & Quota
+   */
+  getSpotMarginInterestAndQuota(coin: string): Promise<
+    APIResponseV3WithTime<{
+      list: {
+        coin: string;
+        interestRate: string;
+        loanAbleAmount: string;
+        maxLoanAmount: string;
+      }[];
+    }>
+  > {
+    return this.getPrivate('/v5/spot-cross-margin-trade/loan-info', {
+      coin,
+    });
+  }
+
+  /**
+   * Get Loan Account Info
+   */
+  getSpotMarginLoanAccountInfo(): Promise<
+    APIResponseV3WithTime<{
+      acctBalanceSum: string;
+      debtBalanceSum: string;
+      loanAccountList: {
+        free: string;
+        interest: string;
+        loan: string;
+        remainAmount: string;
+        locked: string;
+        tokenId: string;
+        total: string;
+      }[];
+      riskRate: string;
+      status: number;
+      switchStatus: number;
+    }>
+  > {
+    return this.getPrivate('/v5/spot-cross-margin-trade/account');
+  }
+
+  /**
+   * Borrow
+   */
+  spotMarginBorrow(params: { coin: string; qty: string }): Promise<
+    APIResponseV3WithTime<{
+      transactId: string;
+    }>
+  > {
+    return this.postPrivate('/v5/spot-cross-margin-trade/loan', params);
+  }
+
+  /**
+   * Repay
+   */
+  spotMarginRepay(params: {
+    coin: string;
+    qty?: string;
+    completeRepayment: 0 | 1;
+  }): Promise<
+    APIResponseV3WithTime<{
+      repayId: string;
+    }>
+  > {
+    return this.postPrivate('/v5/spot-cross-margin-trade/repay', params);
+  }
+
+  /**
+   * Get Borrow Order Detail
+   */
+  getSpotMarginBorrowOrderDetail(params?: {
+    startTime?: number;
+    endTime?: number;
+    coin?: string;
+    status?: 0 | 1 | 2;
+    limit?: number;
+  }): Promise<
+    APIResponseV3WithTime<{
+      list: {
+        accountId: string;
+        coin: string;
+        createdTime: number;
+        id: string;
+        interestAmount: string;
+        interestBalance: string;
+        loanAmount: string;
+        loanBalance: string;
+        remainAmount: string;
+        status: string;
+        type: string;
+      }[];
+    }>
+  > {
+    return this.getPrivate('/v5/spot-cross-margin-trade/orders', params);
+  }
+
+  /**
+   * Get Repayment Order Detail
+   */
+  getSpotMarginRepaymentOrderDetail(params?: {
+    startTime?: number;
+    endTime?: number;
+    coin?: string;
+    limit?: number;
+  }): Promise<
+    APIResponseV3WithTime<{
+      list: {
+        accountId: string;
+        coin: string;
+        repaidAmount: string;
+        repayId: string;
+        repayMarginOrderId: string;
+        repayTime: string;
+        transactIds: {
+          repaidInterest: string;
+          repaidPrincipal: string;
+          repaidSerialNumber: string;
+          transactId: string;
+        }[];
+      }[];
+    }>
+  > {
+    return this.getPrivate('/v5/spot-cross-margin-trade/repay-history', params);
+  }
+
+  /**
+   * Turn spot margin trade on / off in your NORMAL account.
+   */
+  toggleSpotCrossMarginTrade(params: {
+    switch: 1 | 0;
+  }): Promise<APIResponseV3WithTime<{ switchStatus: '1' | '0' }>> {
+    return this.postPrivate('/v5/spot-cross-margin-trade/switch', params);
+  }
+
+  /**
+   *
+   ****** Institutional Lending
+   *
+   */
+
+  /**
+   * Get Product Info
+   */
+  getInstitutionalLendingProductInfo(
+    productId?: string,
+  ): Promise<APIResponseV3WithTime<{ marginProductInfo: any[] }>> {
+    return this.get('/v5/ins-loan/product-infos', { productId });
+  }
+
+  /**
+   * Get Margin Coin Info
+   */
+  getInstitutionalLendingMarginCoinInfo(
+    productId?: string,
+  ): Promise<APIResponseV3WithTime<{ marginToken: any[] }>> {
+    return this.get('/v5/ins-loan/ensure-tokens', { productId });
+  }
+
+  /**
+   * Get Margin Coin Info With Conversion Rate
+   */
+  getInstitutionalLendingMarginCoinInfoWithConversionRate(
+    productId?: string,
+  ): Promise<APIResponseV3WithTime<{ marginToken: any[] }>> {
+    return this.get('/v5/ins-loan/ensure-tokens-convert', { productId });
+  }
+
+  /**
+   * Get Loan Orders
+   */
+  getInstitutionalLendingLoanOrders(params?: {
+    orderId?: string;
+    startTime?: number;
+    endTime?: number;
+    limit?: number;
+  }): Promise<APIResponseV3WithTime<{ marginToken: any[] }>> {
+    return this.getPrivate('/v5/ins-loan/loan-order', params);
+  }
+
+  /**
+   * Get Repay Orders
+   */
+  getInstitutionalLendingRepayOrders(params?: {
+    startTime?: number;
+    endTime?: number;
+    limit?: number;
+  }): Promise<APIResponseV3WithTime<{ repayInfo: any[] }>> {
+    return this.getPrivate('/v5/ins-loan/repaid-history', params);
+  }
+
+  /**
+   * Get LTV
+   */
+  getInstitutionalLendingLTV(): Promise<
+    APIResponseV3WithTime<{ ltvInfo: any[] }>
+  > {
+    return this.getPrivate('/v5/ins-loan/ltv');
+  }
+
+  /**
+   * Get LTV with Ladder Conversion Rate
+   */
+  getInstitutionalLendingLTVWithLadderConversionRate(): Promise<
+    APIResponseV3WithTime<{ ltvInfo: any[] }>
+  > {
+    return this.getPrivate('/v5/ins-loan/ltv-convert');
   }
 }

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -1031,6 +1031,17 @@ export class RestClientV5 extends BaseRestClient {
   }
 
   /**
+   * Set auto transfer account after deposit. The same function as the setting for Deposit on web GUI
+   */
+  setDepositAccount(params: { accountType: AccountTypeV5 }): Promise<
+    APIResponseV3WithTime<{
+      status: 0 | 1;
+    }>
+  > {
+    return this.postPrivate('/v5/asset/deposit/deposit-to-account', params);
+  }
+
+  /**
    * Query deposit records.
    *
    * TIP
@@ -1093,6 +1104,21 @@ export class RestClientV5 extends BaseRestClient {
 
   /**
    * Query the deposit address information of SUB account.
+   */
+  getSubDepositAddress(
+    coin: string,
+    chainType: string,
+    subMemberId: string,
+  ): Promise<APIResponseV3WithTime<DepositAddressResultV5>> {
+    return this.getPrivate('/v5/asset/deposit/query-sub-member-address', {
+      coin,
+      chainType,
+      subMemberId,
+    });
+  }
+
+  /**
+   * Query the deposit address information of SUB account.
    *
    * CAUTION
    * Can use master UID's api key only
@@ -1128,6 +1154,15 @@ export class RestClientV5 extends BaseRestClient {
     params?: GetWithdrawalRecordsParamsV5,
   ): Promise<APIResponseV3<{ rows: WithdrawalRecordV5[] }>> {
     return this.getPrivate('/v5/asset/withdraw/query-record', params);
+  }
+
+  /**
+   * Query withdrawable amount.
+   */
+  getWithdrawableAmount(params: {
+    coin: string;
+  }): Promise<APIResponseV3<{ rows: WithdrawalRecordV5[] }>> {
+    return this.getPrivate('/v5/asset/withdraw/withdrawable-amount', params);
   }
 
   /**

--- a/src/types/request/contract.ts
+++ b/src/types/request/contract.ts
@@ -5,21 +5,24 @@ import { USDCOrderFilter, USDCTimeInForce } from './usdc-shared';
 export interface ContractOrderRequest {
   symbol: string;
   side: OrderSide;
-  positionIdx?: '0' | '1' | '2';
   orderType: UMOrderType;
   qty: string;
+  timeInForce: USDCTimeInForce;
   price?: string;
   triggerDirection?: '1' | '2';
   triggerPrice?: string;
   triggerBy?: string;
-  tpTriggerBy?: string;
-  slTriggerBy?: string;
-  timeInForce: USDCTimeInForce;
+  positionIdx?: '0' | '1' | '2';
   orderLinkId?: string;
   takeProfit?: string;
   stopLoss?: string;
+  tpTriggerBy?: string;
+  slTriggerBy?: string;
   reduceOnly?: boolean;
   closeOnTrigger?: boolean;
+  tpslMode?: 'Partial' | 'Full';
+  tpOrderType?: UMOrderType;
+  slOrderType?: UMOrderType;
 }
 
 export interface ContractHistoricOrdersRequest {
@@ -39,17 +42,19 @@ export interface ContractCancelOrderRequest {
 }
 
 export interface ContractModifyOrderRequest {
+  symbol: string;
   orderId?: string;
   orderLinkId?: string;
-  symbol: string;
-  qty?: string;
   price?: string;
+  qty?: string;
+  triggerPrice?: string;
   takeProfit?: string;
   stopLoss?: string;
   tpTriggerBy?: string;
   slTriggerBy?: string;
   triggerBy?: string;
-  triggerPrice?: string;
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
 }
 
 export interface ContractActiveOrdersRequest {
@@ -91,12 +96,17 @@ export interface ContractSetTPSLRequest {
   symbol: string;
   takeProfit?: string;
   stopLoss?: string;
-  activePrice?: string;
-  trailingStop?: string;
+  tpslMode?: 'Full' | 'Partial';
+  tpSize?: string;
+  slSize?: string;
   tpTriggerBy?: string;
   slTriggerBy?: string;
-  slSize?: string;
-  tpSize?: string;
+  trailingStop?: string;
+  activePrice?: string;
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
+  tpOrderType?: UMOrderType;
+  slOrderType?: UMOrderType;
   /** 0-one-way, 1-buy side, 2-sell side */
   positionIdx?: 0 | 1 | 2;
 }

--- a/src/types/request/index.ts
+++ b/src/types/request/index.ts
@@ -12,6 +12,7 @@ export * from './v5-account';
 export * from './v5-asset';
 export * from './v5-market';
 export * from './v5-position';
+export * from './v5-pre-upgrade';
 export * from './v5-trade';
 export * from './v5-user';
 export * from './v5-spot-leverage-token';

--- a/src/types/request/v5-account.ts
+++ b/src/types/request/v5-account.ts
@@ -13,6 +13,12 @@ export interface GetBorrowHistoryParamsV5 {
   cursor?: string;
 }
 
+export interface GetFeeRateParamsV5 {
+  category: CategoryV5;
+  symbol?: string;
+  baseCoin?: string;
+}
+
 export interface GetTransactionLogParamsV5 {
   accountType?: AccountTypeV5;
   category?: CategoryV5;

--- a/src/types/request/v5-market.ts
+++ b/src/types/request/v5-market.ts
@@ -1,5 +1,5 @@
 import { KlineIntervalV3 } from '../shared';
-import { CategoryV5, OptionTypeV5 } from '../v5-shared';
+import { CategoryV5, InstrumentStatusV5, OptionTypeV5 } from '../v5-shared';
 
 export interface GetKlineParamsV5 {
   category: 'spot' | 'linear' | 'inverse';
@@ -40,6 +40,7 @@ export interface GetPremiumIndexPriceKlineParamsV5 {
 export interface GetInstrumentsInfoParamsV5 {
   category: CategoryV5;
   symbol?: string;
+  status?: InstrumentStatusV5;
   baseCoin?: string;
   limit?: number;
   cursor?: string;
@@ -95,7 +96,7 @@ export interface GetOpenInterestParamsV5 {
 export interface GetHistoricalVolatilityParamsV5 {
   category: 'option';
   baseCoin?: string;
-  period?: number;
+  period?: 7 | 14 | 21 | 30 | 60 | 90 | 180 | 270;
   startTime?: number;
   endTime?: number;
 }
@@ -111,6 +112,14 @@ export interface GetRiskLimitParamsV5 {
 
 export interface GetOptionDeliveryPriceParamsV5 {
   category: 'option';
+  symbol?: string;
+  baseCoin?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface GetDeliveryPriceParamsV5 {
+  category: 'linear' | 'inverse' | 'option';
   symbol?: string;
   baseCoin?: string;
   limit?: number;

--- a/src/types/request/v5-position.ts
+++ b/src/types/request/v5-position.ts
@@ -2,6 +2,7 @@ import {
   CategoryV5,
   ExecTypeV5,
   OrderTriggerByV5,
+  OrderTypeV5,
   PositionIdx,
   TPSLModeV5,
 } from '../v5-shared';
@@ -51,16 +52,21 @@ export interface SetRiskLimitParamsV5 {
 }
 
 export interface SetTradingStopParamsV5 {
-  symbol: string;
   category: CategoryV5;
+  symbol: string;
   takeProfit?: string;
   stopLoss?: string;
   trailingStop?: string;
   tpTriggerBy?: OrderTriggerByV5;
   slTriggerBy?: OrderTriggerByV5;
   activePrice?: string;
+  tpslMode?: TPSLModeV5;
   tpSize?: string;
   slSize?: string;
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
+  tpOrderType?: OrderTypeV5;
+  slOrderType?: OrderTypeV5;
   positionIdx: PositionIdx;
 }
 
@@ -69,6 +75,13 @@ export interface SetAutoAddMarginParamsV5 {
   symbol: string;
   autoAddMargin: 0 | 1;
   positionIdx?: PositionIdx;
+}
+
+export interface AddOrReduceMarginParamsV5 {
+  category: 'linear' | 'inverse';
+  symbol: string;
+  margin: string;
+  positionIDex?: PositionIdx;
 }
 
 export interface GetExecutionListParamsV5 {

--- a/src/types/request/v5-pre-upgrade.ts
+++ b/src/types/request/v5-pre-upgrade.ts
@@ -1,0 +1,37 @@
+import { ExecTypeV5 } from '../v5-shared';
+
+export interface GetPreUpgradeOrderHistoryParamsV5 {
+  category: 'linear' | 'inverse';
+  symbol?: string;
+  baseCoin?: string;
+  orderId?: string;
+  orderLinkId?: string;
+  orderFilter?: 'Order' | 'StopOrder';
+  orderStatus?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface GetPreUpgradeTradeHistoryParamsV5 {
+  category: 'linear' | 'inverse';
+  symbol?: string;
+  orderId?: string;
+  orderLinkId?: string;
+  baseCoin?: string;
+  startTime?: number;
+  endTime?: number;
+  execType?: ExecTypeV5;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface GetPreUpgradeClosedPnlParamsV5 {
+  category: 'linear' | 'inverse';
+  symbol: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  cursor?: string;
+}

--- a/src/types/request/v5-trade.ts
+++ b/src/types/request/v5-trade.ts
@@ -1,7 +1,9 @@
 import {
   CategoryV5,
   OrderFilterV5,
+  OrderSMPTypeV5,
   OrderSideV5,
+  OrderStatusV5,
   OrderTimeInForceV5,
   OrderTriggerByV5,
   OrderTypeV5,
@@ -30,7 +32,13 @@ export interface OrderParamsV5 {
   slTriggerBy?: OrderTriggerByV5;
   reduceOnly?: boolean;
   closeOnTrigger?: boolean;
+  smpType?: OrderSMPTypeV5;
   mmp?: boolean;
+  tpslMode?: 'Full' | 'Partial';
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
+  tpOrderType?: OrderTypeV5;
+  slOrderType?: OrderTypeV5;
 }
 
 export interface AmendOrderParamsV5 {
@@ -47,6 +55,8 @@ export interface AmendOrderParamsV5 {
   tpTriggerBy?: OrderTriggerByV5;
   slTriggerBy?: OrderTriggerByV5;
   triggerBy?: OrderTriggerByV5;
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
 }
 
 export interface CancelOrderParamsV5 {
@@ -66,6 +76,21 @@ export interface GetAccountOrdersParams {
   orderLinkId?: string;
   openOnly?: 0 | 1 | 2;
   orderFilter?: OrderFilterV5;
+  orderStatus?: OrderStatusV5;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface GetAccountHistoricOrdersPArams {
+  category: CategoryV5;
+  symbol?: string;
+  baseCoin?: string;
+  orderId?: string;
+  orderLinkId?: string;
+  orderFilter?: OrderFilterV5;
+  orderStatus?: OrderStatusV5;
+  startTime?: number;
+  endTime?: number;
   limit?: number;
   cursor?: string;
 }
@@ -89,6 +114,7 @@ export interface BatchOrderParamsV5 {
   orderLinkId: string;
   reduceOnly?: boolean;
   mmp?: boolean;
+  smpType?: OrderSMPTypeV5;
 }
 
 export interface BatchAmendOrderParamsV5 {

--- a/src/types/response/contract.ts
+++ b/src/types/response/contract.ts
@@ -10,33 +10,43 @@ export interface ContractListResult<TList = any> {
 
 export interface ContractHistoricOrder {
   symbol: string;
+  orderId: string;
+  orderLinkId: string;
   side: string;
   orderType: string;
   price: string;
+  iv: string;
   qty: string;
-  reduceOnly: boolean;
   timeInForce: string;
   orderStatus: string;
-  leavesQty: string;
-  leavesValue: string;
-  cumExecQty: string;
-  cumExecValue: string;
-  cumExecFee: string;
+  positionIdx: number;
   lastPriceOnCreated: string;
-  rejectReason: string;
-  orderLinkId: string;
   createdTime: string;
   updatedTime: string;
-  orderId: string;
+  cancelType: string;
+  rejectReason: string;
   stopOrderType: string;
+  triggerDirection: number;
+  triggerBy: string;
+  triggerPrice: string;
+  cumExecValue: string;
+  cumExecFee: string;
+  cumExecQty: string;
+  leavesValue: string;
+  leavesQty: string;
   takeProfit: string;
   stopLoss: string;
+  tpslMode: string;
+  tpLimitPrice: string;
+  slLimitPrice: string;
   tpTriggerBy: string;
   slTriggerBy: string;
-  triggerPrice: string;
+  reduceOnly: boolean;
   closeOnTrigger: boolean;
-  triggerDirection: number;
-  positionIdx: number;
+  blockTradeId: string;
+  smpType: string;
+  smpGroup: number;
+  smpOrderId: string;
 }
 
 export interface ContractSymbolTicker {

--- a/src/types/response/v5-account.ts
+++ b/src/types/response/v5-account.ts
@@ -78,6 +78,7 @@ export interface CoinGreeksV5 {
 
 export interface FeeRateV5 {
   symbol: string;
+  baseCoin: string;
   takerFeeRate: string;
   makerFeeRate: string;
 }

--- a/src/types/response/v5-market.ts
+++ b/src/types/response/v5-market.ts
@@ -24,7 +24,7 @@ export type OHLCVKlineV5 = [
   string,
   string,
   string,
-  string
+  string,
 ];
 
 /**
@@ -257,7 +257,14 @@ export interface RiskLimitV5 {
   maxLeverage: string;
 }
 
+/** @deprecated use DeliveryPriceV5 instead */
 export interface OptionDeliveryPriceV5 {
+  symbol: string;
+  deliveryPrice: string;
+  deliveryTime: string;
+}
+
+export interface DeliveryPriceV5 {
   symbol: string;
   deliveryPrice: string;
   deliveryTime: string;

--- a/src/types/response/v5-position.ts
+++ b/src/types/response/v5-position.ts
@@ -43,6 +43,32 @@ export interface SetRiskLimitResultV5 {
   riskLimitValue: string;
 }
 
+export interface AddOrReduceMarginResultV5 {
+  category: CategoryV5;
+  symbol: string;
+  positionIdx: PositionIdx;
+  riskId: number;
+  riskLimitValue: string;
+  size: string;
+  avgPrice: string;
+  liqPrice: string;
+  bustPrice: string;
+  markPrice: string;
+  positionValue: string;
+  leverage: string;
+  autoAddMargin: 0 | 1;
+  positionStatus: 'Normal' | 'Liq' | 'Adl';
+  positionIM: string;
+  positionMM: string;
+  takeProfit: string;
+  stopLoss: string;
+  trailingStop: string;
+  unrealisedPnl: string;
+  cumRealisedPnl: string;
+  createdTime: string;
+  updatedTime: string;
+}
+
 export interface ExecutionV5 {
   symbol: string;
   orderId: string;

--- a/src/types/response/v5-position.ts
+++ b/src/types/response/v5-position.ts
@@ -94,6 +94,7 @@ export interface ExecutionV5 {
   indexPrice: string;
   underlyingPrice?: string;
   blockTradeId?: string;
+  closedSize?: string;
 }
 
 export interface ClosedPnLV5 {

--- a/src/types/response/v5-trade.ts
+++ b/src/types/response/v5-trade.ts
@@ -42,6 +42,9 @@ export interface AccountOrderV5 {
   triggerPrice?: string;
   takeProfit?: string;
   stopLoss?: string;
+  tpslMode: 'Full' | 'Partial' | '';
+  tpLimitPrice: string;
+  slLimitPrice: string;
   tpTriggerBy?: OrderTriggerByV5;
   slTriggerBy?: OrderTriggerByV5;
   triggerDirection?: number;
@@ -49,6 +52,10 @@ export interface AccountOrderV5 {
   lastPriceOnCreated?: string;
   reduceOnly?: boolean;
   closeOnTrigger?: boolean;
+  placeType: 'iv' | 'price' | '';
+  smpType: string;
+  smpGroup: string;
+  smpOrderId: string;
   createdTime: string;
   updatedTime: string;
 }

--- a/src/types/v5-shared.ts
+++ b/src/types/v5-shared.ts
@@ -4,7 +4,12 @@ export type ContractTypeV5 =
   | 'LinearPerpetual'
   | 'InverseFutures';
 
-export type InstrumentStatusV5 = 'Pending' | 'Trading' | 'Settling' | 'Closed';
+export type InstrumentStatusV5 =
+  | 'PreLaunch'
+  | 'Trading'
+  | 'Settling'
+  | 'Delivering'
+  | 'Closed';
 
 export type OrderFilterV5 = 'Order' | 'tpslOrder';
 export type OrderSideV5 = 'Buy' | 'Sell';

--- a/src/types/v5-shared.ts
+++ b/src/types/v5-shared.ts
@@ -11,6 +11,13 @@ export type OrderSideV5 = 'Buy' | 'Sell';
 export type OrderTypeV5 = 'Market' | 'Limit';
 export type OrderTimeInForceV5 = 'GTC' | 'IOC' | 'FOK' | 'PostOnly';
 export type OrderTriggerByV5 = 'LastPrice' | 'IndexPrice' | 'MarkPrice';
+
+export type OrderSMPTypeV5 =
+  | 'None'
+  | 'CancelMaker'
+  | 'CancelTaker'
+  | 'CancelBoth';
+
 export type OrderStatusV5 =
   | 'Created'
   | 'New'
@@ -166,7 +173,7 @@ export interface PermissionsV5 {
 
 export interface CategoryCursorListV5<
   T extends unknown[],
-  TCategory extends CategoryV5 = CategoryV5
+  TCategory extends CategoryV5 = CategoryV5,
 > {
   category: TCategory;
   list: T;
@@ -183,7 +190,7 @@ export interface CursorListV5<T extends unknown[]> {
 
 export interface CategoryListV5<
   T extends unknown[],
-  TCategory extends CategoryV5
+  TCategory extends CategoryV5,
 > {
   category: TCategory;
   list: T;
@@ -191,7 +198,7 @@ export interface CategoryListV5<
 
 export interface CategorySymbolListV5<
   T extends unknown[],
-  TCategory extends CategoryV5
+  TCategory extends CategoryV5,
 > {
   category: TCategory;
   symbol: string;

--- a/src/types/v5-shared.ts
+++ b/src/types/v5-shared.ts
@@ -172,6 +172,8 @@ export interface PermissionsV5 {
   Wallet?: string[];
   Options?: string[];
   Derivatives?: string[];
+  CopyTrading?: string[];
+  BlockTrade?: string[];
   Exchange?: string[];
   NFT?: string[];
 }

--- a/test/v5/private.read.test.ts
+++ b/test/v5/private.read.test.ts
@@ -105,7 +105,7 @@ describe('Private READ V5 REST API Endpoints', () => {
     });
 
     it('getFeeRate()', async () => {
-      expect(await api.getFeeRate()).toMatchObject({
+      expect(await api.getFeeRate({ category: 'linear' })).toMatchObject({
         ...successResponseObjectV3(),
       });
     });


### PR DESCRIPTION
## Summary
- Work on examples for API documentation website.
- Work on missing endpoints & missing request/response parameters. Fixes #261.
<!-- Add a brief description of the pr: -->

## Additional Information
### Rest Client V5
#### Deprecations
- Deprecated `getOptionDeliveryPrice`, use `getDeliveryPrice` instead.
  - Deprecated `GetOptionDeliveryPriceParamsV5`, use `GetDeliveryPriceParamsV5` instead.
  - Deprecated `OptionDeliveryPriceV5`, use `DeliveryPriceV5` instead.

#### Breaking Changes
- v5.getFeeRate(params) now takes an object instead of a string and now supports all product groups.
  - The previous format was unusable since the `category` parameter became required.

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
