### PR TITLE
fix(#286): automatic type determination for instrument info

### DIFF
--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -231,9 +231,9 @@ export class RestClientV5 extends BaseRestClient {
    *
    * Note: Spot does not support pagination, so limit & cursor are invalid.
    */
-  getInstrumentsInfo(
-    params: GetInstrumentsInfoParamsV5,
-  ): Promise<APIResponseV3WithTime<InstrumentInfoResponseV5>> {
+  getInstrumentsInfo<C extends CategoryV5>(
+    params: GetInstrumentsInfoParamsV5 & { category: C },
+  ): Promise<APIResponseV3WithTime<InstrumentInfoResponseV5<C>>> {
     return this.get('/v5/market/instruments-info', params);
   }
 

--- a/src/types/response/v5-market.ts
+++ b/src/types/response/v5-market.ts
@@ -1,6 +1,8 @@
 import {
   CategoryCursorListV5,
+  CategoryV5,
   ContractTypeV5,
+  CursorListV5,
   InstrumentStatusV5,
   OptionTypeV5,
   OrderSideV5,
@@ -110,10 +112,14 @@ export interface SpotInstrumentInfoV5 {
   };
 }
 
-export type InstrumentInfoResponseV5 =
-  | CategoryCursorListV5<LinearInverseInstrumentInfoV5[], 'linear' | 'inverse'>
-  | CategoryCursorListV5<OptionInstrumentInfoV5[], 'option'>
-  | CategoryCursorListV5<SpotInstrumentInfoV5[], 'spot'>;
+type InstrumentInfoV5Mapping = {
+  linear: LinearInverseInstrumentInfoV5[],
+  inverse: LinearInverseInstrumentInfoV5[],
+  option: OptionInstrumentInfoV5[],
+  spot: SpotInstrumentInfoV5[]
+};
+
+export type InstrumentInfoResponseV5<C extends CategoryV5> = CategoryCursorListV5<InstrumentInfoV5Mapping[C], C>;
 
 export default interface OrderbookLevelV5 {
   price: string;

--- a/src/types/response/v5-market.ts
+++ b/src/types/response/v5-market.ts
@@ -2,7 +2,6 @@ import {
   CategoryCursorListV5,
   CategoryV5,
   ContractTypeV5,
-  CursorListV5,
   InstrumentStatusV5,
   OptionTypeV5,
   OrderSideV5,


### PR DESCRIPTION
## Summary
This pull request fixes the issue where the result type was not automatically being determined.

## Additional Information

Old behaviour:

```ts
// ... { category: 'linear' }
const [instrumentInfo] = response.result.list;
const stepSize = instrumentInfo.lotSizeFilter.qtyStep;
// qtyStep is not available due to it being a combined type
```

New behaviour:

```ts
// ... { category: 'linear' }
const [instrumentInfo] = response.result.list;
const stepSize = instrumentInfo.lotSizeFilter.qtyStep;
// qtyStep is now available due the return type being determined from `category`
```

Closes #286 