### PR TITLE
_call: add rate limit to response data

### DIFF
--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -323,6 +323,7 @@ export default abstract class BaseRestClient {
     return axios(options)
       .then((response) => {
         if (response.status == 200) {
+	  response.data = {...response.data, headers: response.headers};
           return response.data;
         }
 


### PR DESCRIPTION
append response headers to returned data as rate limit info are inside headers.

## Summary
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
