### PR TITLE
feat(account-order-v5): adds category property on interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "3.7.6",
+  "version": "3.7.7",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/response/v5-trade.ts
+++ b/src/types/response/v5-trade.ts
@@ -58,6 +58,7 @@ export interface AccountOrderV5 {
   smpOrderId: string;
   createdTime: string;
   updatedTime: string;
+  category: CategoryV5;
 }
 
 export interface BatchCreateOrderResultV5 {


### PR DESCRIPTION
## Summary
Adds `category` property of type `CategoryV5` on `AccountOrderV5` interface, according to returned json structure from exchange order update event.