### PR TITLE
v3.9.8: Updated V5 `InstrumentInfo` types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "3.9.7",
+  "version": "3.9.8",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/response/v5-market.ts
+++ b/src/types/response/v5-market.ts
@@ -2,7 +2,9 @@ import {
   CategoryCursorListV5,
   CategoryV5,
   ContractTypeV5,
+  CopyTradingV5,
   InstrumentStatusV5,
+  MarginTradingV5,
   OptionTypeV5,
   OrderSideV5,
 } from '../v5-shared';
@@ -61,6 +63,7 @@ export interface LinearInverseInstrumentInfoV5 {
   };
   lotSizeFilter: {
     maxOrderQty: string;
+    maxMktOrderQty: string;
     minOrderQty: string;
     qtyStep: string;
     postOnlyMaxOrderQty?: string;
@@ -68,6 +71,9 @@ export interface LinearInverseInstrumentInfoV5 {
   unifiedMarginTrade: boolean;
   fundingInterval: number;
   settleCoin: string;
+  copyTrading: CopyTradingV5;
+  upperFundingRate: string;
+  lowerFundingRate: string;
 }
 
 export interface OptionInstrumentInfoV5 {
@@ -98,6 +104,7 @@ export interface SpotInstrumentInfoV5 {
   quoteCoin: string;
   innovation: '0' | '1';
   status: InstrumentStatusV5;
+  marginTrading: MarginTradingV5;
   lotSizeFilter: {
     basePrecision: string;
     quotePrecision: string;
@@ -109,6 +116,10 @@ export interface SpotInstrumentInfoV5 {
   priceFilter: {
     tickSize: string;
   };
+  riskParameters: {
+    limitParameter: string;
+    marketParameter: string;
+  }
 }
 
 type InstrumentInfoV5Mapping = {

--- a/src/types/response/v5-market.ts
+++ b/src/types/response/v5-market.ts
@@ -67,6 +67,7 @@ export interface LinearInverseInstrumentInfoV5 {
     minOrderQty: string;
     qtyStep: string;
     postOnlyMaxOrderQty?: string;
+    minNotionalValue?: string;
   };
   unifiedMarginTrade: boolean;
   fundingInterval: number;

--- a/src/types/v5-shared.ts
+++ b/src/types/v5-shared.ts
@@ -3,6 +3,7 @@ export type ContractTypeV5 =
   | 'InversePerpetual'
   | 'LinearPerpetual'
   | 'InverseFutures';
+export type CopyTradingV5 = 'none' | 'both' | 'utaOnly' | 'normalOnly';
 
 export type InstrumentStatusV5 =
   | 'PreLaunch'
@@ -10,6 +11,8 @@ export type InstrumentStatusV5 =
   | 'Settling'
   | 'Delivering'
   | 'Closed';
+
+export type MarginTradingV5 = 'none' | 'both' | 'utaOnly' | 'normalSpotOnly';
 
 export type OrderFilterV5 = 'Order' | 'tpslOrder' | 'StopOrder';
 export type OrderSideV5 = 'Buy' | 'Sell';


### PR DESCRIPTION
## Summary
 Missing attributes have been added according to the documentation

## Additional Information
`postOnlyMaxOrderQty` should be removed from `LinearInverseInstrumentInfoV5` as this has been replaced by `maxOrderQty`. The API still returns the value, so I left it for now.
