### PR TITLE
v3.10.2: Added and updated V5 types. Added type guards.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/response/v5-position.ts
+++ b/src/types/response/v5-position.ts
@@ -4,6 +4,8 @@ import {
   OrderSideV5,
   OrderTypeV5,
   PositionIdx,
+  PositionSideV5,
+  PositionStatusV5,
   StopOrderTypeV5,
   TPSLModeV5,
   TradeModeV5,
@@ -14,16 +16,16 @@ export interface PositionV5 {
   riskId: number;
   riskLimitValue: string;
   symbol: string;
-  side: 'Buy' | 'Sell' | 'None';
+  side: PositionSideV5;
   size: string;
   avgPrice: string;
   positionValue: string;
   tradeMode: TradeModeV5;
   autoAddMargin?: number;
-  positionStatus: 'Normal' | 'Liq' | 'Adl';
+  positionStatus: PositionStatusV5;
   leverage?: string;
   markPrice: string;
-  liqPrice: string;
+  liqPrice: string | '';
   bustPrice?: string;
   positionIM?: string;
   positionMM?: string;
@@ -31,10 +33,21 @@ export interface PositionV5 {
   takeProfit?: string;
   stopLoss?: string;
   trailingStop?: string;
+  sessionAvgPrice: string | '';
+  delta?: string;
+  gamma?: string;
+  vega?: string;
+  theta?: string;
   unrealisedPnl: string;
+  curRealisedPnl: string;
   cumRealisedPnl: string;
+  adlRankIndicator: number;
+  isReduceOnly: boolean;
+  mmrSysUpdatedTime: string | '';
+  leverageSysUpdatedTime: string | '';
   createdTime: string;
   updatedTime: string;
+  seq: number;
 }
 
 export interface SetRiskLimitResultV5 {
@@ -57,7 +70,7 @@ export interface AddOrReduceMarginResultV5 {
   positionValue: string;
   leverage: string;
   autoAddMargin: 0 | 1;
-  positionStatus: 'Normal' | 'Liq' | 'Adl';
+  positionStatus: PositionStatusV5;
   positionIM: string;
   positionMM: string;
   takeProfit: string;

--- a/src/types/v5-shared.ts
+++ b/src/types/v5-shared.ts
@@ -153,6 +153,16 @@ export type StopOrderTypeV5 =
  */
 export type PositionIdx = 0 | 1 | 2;
 
+/**
+ * Position status.
+ * 
+ * - 'Normal'
+ * - 'Liq' in the liquidation progress
+ * - 'Adl' in the auto-deleverage progress
+ */
+export type PositionStatusV5 = 'Normal' | 'Liq' | 'Adl';
+export type PositionSideV5 = 'Buy' | 'Sell';
+
 export type OptionTypeV5 = 'Call' | 'Put';
 
 /**

--- a/src/types/v5-shared.ts
+++ b/src/types/v5-shared.ts
@@ -161,7 +161,7 @@ export type PositionIdx = 0 | 1 | 2;
  * - 'Adl' in the auto-deleverage progress
  */
 export type PositionStatusV5 = 'Normal' | 'Liq' | 'Adl';
-export type PositionSideV5 = 'Buy' | 'Sell';
+export type PositionSideV5 = 'Buy' | 'Sell' | 'None' | '';
 
 export type OptionTypeV5 = 'Call' | 'Put';
 

--- a/src/types/v5-shared.ts
+++ b/src/types/v5-shared.ts
@@ -223,7 +223,10 @@ export type ExecTypeV5 =
   | 'AdlTrade'
   | 'Funding'
   | 'BustTrade'
-  | 'Settle';
+  | 'Settle'
+  | 'BlockTrade'
+  | 'MovePosition'
+  | 'UNKNOWN';
 
 /**
  * Withdraw type. 0(default): on chain. 1: off chain. 2: all.

--- a/src/types/v5-shared.ts
+++ b/src/types/v5-shared.ts
@@ -95,7 +95,9 @@ export type OrderCreateTypeV5 =
   /** Order created by Ice berg strategy - web/app. */
   | 'CreateByIceBerg'
   /** Order created by arbitrage - web/app. */
-  | 'CreateByArbitrage';
+  | 'CreateByArbitrage'
+  /** Option dynamic delta hedge order - web/app */
+  | 'CreateByDdh';
 
 export type OrderCancelTypeV5 =
   | 'CancelByUser'

--- a/src/types/websocket.events.ts
+++ b/src/types/websocket.events.ts
@@ -2,6 +2,7 @@ import {
   CategoryV5,
   ExecTypeV5,
   OCOTriggerTypeV5,
+  OrderCancelTypeV5,
   OrderCreateTypeV5,
   OrderRejectReasonV5,
   OrderSMPTypeV5,
@@ -45,58 +46,60 @@ export interface WSOrderbookEventV5 {
 }
 
 export interface WSAccountOrderV5 {
-  qty: string;
-  price: string;
-  symbol: string;
+  category: CategoryV5;
   orderId: string;
-  orderIv: string;
-  stopLoss: string;
-  smpGroup: number;
+  orderLinkId: string;
+  isLeverage: string;
+  blockTradeId: string;
+  symbol: string;
+  price: string;
+  qty: string;
   side: OrderSideV5;
-  placeType: string;
+  positionIdx: number;
+  orderStatus: OrderStatusV5;
+  createType: OrderCreateTypeV5;
+  cancelType: OrderCancelTypeV5;
+  rejectReason?: OrderRejectReasonV5;
   avgPrice?: string;
   leavesQty?: string;
-  isLeverage: string;
-  cancelType: string;
+  leavesValue?: string;
   cumExecQty: string;
+  cumExecValue: string;
   cumExecFee: string;
-  smpOrderId: string;
+  feeCurrency: string;
+  timeInForce: OrderTimeInForceV5;
+  orderType: OrderTypeV5;
+  stopOrderType: StopOrderTypeV5;
+  ocoTriggerType?: OCOTriggerTypeV5;
+  orderIv: string;
+  marketUnit?: 'baseCoin' | 'quoteCoin';
+  triggerPrice: string;
   takeProfit: string;
-  reduceOnly: boolean;
-  orderLinkId: string;
-  positionIdx: number;
+  stopLoss: string;
+  tpslMode?: TPSLModeV5;
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
   tpTriggerBy: string;
   slTriggerBy: string;
+  triggerDirection: number;
+  triggerBy: OrderTriggerByV5;
+  lastPriceOnCreated: string;
+  reduceOnly: boolean;
+  closeOnTrigger: boolean;
+  placeType: string;
+  smpType: OrderSMPTypeV5;
+  smpGroup: number;
+  smpOrderId: string;
   createdTime: string;
   updatedTime: string;
-  feeCurrency: string;
-  triggerPrice: string;
-  category: CategoryV5;
-  cumExecValue: string;
-  blockTradeId: string;
-  leavesValue?: string;
-  slLimitPrice?: string;
-  tpLimitPrice?: string;
-  tpslMode?: TPSLModeV5;
-  orderType: OrderTypeV5;
-  smpType: OrderSMPTypeV5;
-  closeOnTrigger: boolean;
-  triggerDirection: number;
-  orderStatus: OrderStatusV5;
-  lastPriceOnCreated: string;
-  triggerBy: OrderTriggerByV5;
-  stopOrderType: StopOrderTypeV5;
-  timeInForce: OrderTimeInForceV5;
-  ocoTriggerType?: OCOTriggerTypeV5;
-  rejectReason?: OrderRejectReasonV5;
 }
 
 export interface WSAccountOrderEventV5 {
   id: string;
-  wsKey: WsKey;
   topic: 'order';
   creationTime: number;
   data: WSAccountOrderV5[];
+  wsKey: WsKey;
 }
 
 export interface WSExecutionV5 {

--- a/src/types/websocket.events.ts
+++ b/src/types/websocket.events.ts
@@ -11,6 +11,7 @@ import {
   OrderTimeInForceV5,
   OrderTriggerByV5,
   OrderTypeV5,
+  PositionIdx,
   StopOrderTypeV5,
   TPSLModeV5,
 } from './v5-shared';
@@ -55,7 +56,7 @@ export interface WSAccountOrderV5 {
   price: string;
   qty: string;
   side: OrderSideV5;
-  positionIdx: number;
+  positionIdx: PositionIdx;
   orderStatus: OrderStatusV5;
   createType: OrderCreateTypeV5;
   cancelType: OrderCancelTypeV5;

--- a/src/types/websocket.events.ts
+++ b/src/types/websocket.events.ts
@@ -1,6 +1,8 @@
 import {
   CategoryV5,
+  ExecTypeV5,
   OCOTriggerTypeV5,
+  OrderCreateTypeV5,
   OrderRejectReasonV5,
   OrderSMPTypeV5,
   OrderSideV5,
@@ -95,4 +97,45 @@ export interface WSAccountOrderEventV5 {
   topic: 'order';
   creationTime: number;
   data: WSAccountOrderV5[];
+}
+
+export interface WSExecutionV5 {
+  category: CategoryV5;
+  symbol: string;
+  isLeverage: string;
+  orderId: string;
+  orderLinkId: string;
+  side: OrderSideV5;
+  orderPrice: string;
+  orderQty: string;
+  leavesQty: string;
+  createType: OrderCreateTypeV5;
+  orderType: OrderTypeV5;
+  stopOrderType: StopOrderTypeV5;
+  execFee: string;
+  execId: string;
+  execPrice: string;
+  execQty: string;
+  execType: ExecTypeV5;
+  execValue: string;
+  execTime: string;
+  isMaker: boolean;
+  feeRate: string;
+  tradeIv: string;
+  markIv: string;
+  markPrice: string;
+  indexPrice: string;
+  underlyingPrice: string;
+  blockTradeId: string;
+  closedSize: string;
+  seq: number;
+  marketUnit: string;
+}
+
+export interface WSExecutionEventV5 {
+  id: string;
+  topic: 'execution';
+  creationTime: number;
+  data: WSExecutionV5[];
+  wsKey: WsKey;
 }

--- a/src/types/websocket.events.ts
+++ b/src/types/websocket.events.ts
@@ -12,8 +12,11 @@ import {
   OrderTriggerByV5,
   OrderTypeV5,
   PositionIdx,
+  PositionSideV5,
+  PositionStatusV5,
   StopOrderTypeV5,
   TPSLModeV5,
+  TradeModeV5,
 } from './v5-shared';
 import { WsKey } from './websockets';
 
@@ -43,6 +46,55 @@ export interface WSOrderbookEventV5 {
   /**
    * Internal reference, can be used to determine if this is spot/linear/inverse/etc
    */
+  wsKey: WsKey;
+}
+
+export interface WSPositionV5 {
+  category: string;
+  symbol: string;
+  side: PositionSideV5;
+  size: string;
+  positionIdx: PositionIdx;
+  tradeMode: TradeModeV5;
+  positionValue: string;
+  riskId: number;
+  riskLimitValue: string;
+  entryPrice: string;
+  markPrice: string;
+  leverage: string;
+  positionBalance: string;
+  autoAddMargin: number;
+  positionMM: string;
+  positionIM: string;
+  liqPrice: string;
+  bustPrice: string;
+  tpslMode: string;
+  takeProfit: string;
+  stopLoss: string;
+  trailingStop: string;
+  unrealisedPnl: string;
+  curRealisedPnl: string;
+  sessionAvgPrice: string;
+  delta: string;
+  gamma: string;
+  vega: string;
+  theta: string;
+  cumRealisedPnl: string;
+  positionStatus: PositionStatusV5;
+  adlRankIndicator: number;
+  isReduceOnly: boolean;
+  mmrSysUpdatedTime: string;
+  leverageSysUpdatedTime: string;
+  createdTime: string;
+  updatedTime: string;
+  seq: number;
+}
+
+export interface WSPositionEventV5 {
+  id: string;
+  topic: 'position';
+  creationTime: number;
+  data: WSPositionV5[];
   wsKey: WsKey;
 }
 

--- a/src/types/websocket.events.ts
+++ b/src/types/websocket.events.ts
@@ -20,25 +20,15 @@ import {
 } from './v5-shared';
 import { WsKey } from './websockets';
 
-export interface WSOrderbookEventV5 {
-  topic: string;
+export interface WSPublicTopicEventV5<TTopic extends string, TType, TData> {
+  id?: string;
+  topic: TTopic;
+  type: TType;
+  /** Cross sequence */
+  cs?: number;
   /** Event timestamp */
   ts: number;
-  type: 'delta' | 'snapshot';
-  data: {
-    /** Symbol */
-    s: string;
-    /** [price, qty][] */
-    b: [string, string][];
-    /** [price, qty][] */
-    a: [string, string][];
-    /** Update ID */
-    u: number;
-    /**
-     * Cross sequence
-     */
-    seq: number;
-  };
+  data: TData;
   /**
    * matching engine timestamp (correlated with T from public trade channel)
    */
@@ -48,6 +38,29 @@ export interface WSOrderbookEventV5 {
    */
   wsKey: WsKey;
 }
+
+export interface WSPrivateTopicEventV5<TTopic extends string, TData> {
+  id?: string;
+  topic: TTopic;
+  creationTime: number;
+  data: TData;
+  wsKey: WsKey;
+}
+
+export interface WSOrderbookV5 {
+  /** Symbol */
+  s: string;
+  /** [price, qty][] */
+  b: [string, string][];
+  /** [price, qty][] */
+  a: [string, string][];
+  /** Update ID */
+  u: number;
+  /** Cross sequence */
+  seq: number;
+}
+
+export type WSOrderbookEventV5 = WSPublicTopicEventV5<string, 'delta' | 'snapshot', WSOrderbookV5[]>;
 
 export interface WSPositionV5 {
   category: string;
@@ -90,13 +103,7 @@ export interface WSPositionV5 {
   seq: number;
 }
 
-export interface WSPositionEventV5 {
-  id: string;
-  topic: 'position';
-  creationTime: number;
-  data: WSPositionV5[];
-  wsKey: WsKey;
-}
+export type WSPositionEventV5 = WSPrivateTopicEventV5<'position', WSPositionV5[]>;
 
 export interface WSAccountOrderV5 {
   category: CategoryV5;
@@ -147,13 +154,7 @@ export interface WSAccountOrderV5 {
   updatedTime: string;
 }
 
-export interface WSAccountOrderEventV5 {
-  id: string;
-  topic: 'order';
-  creationTime: number;
-  data: WSAccountOrderV5[];
-  wsKey: WsKey;
-}
+export type WSAccountOrderEventV5 = WSPrivateTopicEventV5<'order', WSAccountOrderV5[]>;
 
 export interface WSExecutionV5 {
   category: CategoryV5;
@@ -188,10 +189,4 @@ export interface WSExecutionV5 {
   marketUnit: string;
 }
 
-export interface WSExecutionEventV5 {
-  id: string;
-  topic: 'execution';
-  creationTime: number;
-  data: WSExecutionV5[];
-  wsKey: WsKey;
-}
+export type WSExecutionEventV5 = WSPrivateTopicEventV5<'execution', WSExecutionV5[]>;

--- a/src/util/typeGuards.ts
+++ b/src/util/typeGuards.ts
@@ -2,7 +2,7 @@
  * Use type guards to narrow down types with minimal efforts.
  */
 
-import { WSAccountOrderEventV5, WSExecutionEventV5, WSOrderbookEventV5 } from '../types/websocket.events';
+import { WSAccountOrderEventV5, WSExecutionEventV5, WSOrderbookEventV5, WSPositionEventV5 } from '../types/websocket.events';
 
 /**
  * Type guard to detect a V5 orderbook event (delta & snapshots)
@@ -26,6 +26,26 @@ export function isWsOrderbookEventV5(
     ['delta', 'snapshot'].includes(event['type']) &&
     event['topic'].startsWith('orderbook')
   );
+}
+
+/**
+ * Type guard to detect a V5 position event.
+ * 
+ * @param event
+ * @returns
+ */
+export function isWsPositionEventV5(
+  event: unknown,
+): event is WSPositionEventV5 {
+  if (
+    typeof event !== 'object' ||
+    !event ||
+    typeof event['topic'] !== 'string'
+  ) {
+    return false;
+  }
+
+  return event['topic'] === 'position';
 }
 
 /**

--- a/src/util/typeGuards.ts
+++ b/src/util/typeGuards.ts
@@ -2,7 +2,7 @@
  * Use type guards to narrow down types with minimal efforts.
  */
 
-import { WSOrderbookEventV5 } from '../types/websocket.events';
+import { WSAccountOrderEventV5, WSExecutionEventV5, WSOrderbookEventV5 } from '../types/websocket.events';
 
 /**
  * Type guard to detect a V5 orderbook event (delta & snapshots)
@@ -26,4 +26,44 @@ export function isWsOrderbookEventV5(
     ['delta', 'snapshot'].includes(event['type']) &&
     event['topic'].startsWith('orderbook')
   );
+}
+
+/**
+ * Type guard to detect a V5 order event.
+ *
+ * @param event
+ * @returns
+ */
+export function isWsAccountOrderEventV5(
+  event: unknown,
+): event is WSAccountOrderEventV5 {
+  if (
+    typeof event !== 'object' ||
+    !event ||
+    typeof event['topic'] !== 'string'
+  ) {
+    return false;
+  }
+
+  return event['topic'] === 'order';
+}
+
+/**
+ * Type guard to detect a V5 execution event.
+ *
+ * @param event
+ * @returns
+ */
+export function isWsExecutionEventV5(
+  event: unknown,
+): event is WSExecutionEventV5 {
+  if (
+    typeof event !== 'object' ||
+    !event ||
+    typeof event['topic'] !== 'string'
+  ) {
+    return false;
+  }
+
+  return event['topic'] === 'execution';
 }


### PR DESCRIPTION
## Summary
This PR adds interfaces and type guards for
- `WSPositionV5`
- `WSPositionEventV5`
- `WSExecutionV5`
- `WSExecutionEventV5`

Types have been added to `v5-shared.ts`
- `PositionStatusV5`
- `PositionSideV5`
and a few other types have been updated according to the docs