### PR TITLE
v3.10.4: Introduce `getSubAccountAllApiKeys`, update `deleteSubApiKey`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bybit-api",
-  "version": "3.10.3",
+  "version": "3.10.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bybit-api",
-      "version": "3.10.3",
+      "version": "3.10.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "3.10.3",
+  "version": "3.10.4",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -82,6 +82,7 @@ import {
   GetRiskLimitParamsV5,
   GetSettlementRecordParamsV5,
   GetSpotLeveragedTokenOrderHistoryParamsV5,
+  GetSubAccountAllApiKeysParamsV5,
   GetSubAccountDepositRecordParamsV5,
   GetTickersParamsV5,
   GetTransactionLogParamsV5,
@@ -126,6 +127,7 @@ import {
   SettlementRecordV5,
   SpotBorrowCheckResultV5,
   SpotLeveragedTokenOrderHistoryV5,
+  SubAccountAllApiKeysResultV5,
   SubMemberV5,
   SwitchIsolatedMarginParamsV5,
   SwitchPositionModeParamsV5,
@@ -142,8 +144,6 @@ import {
   WalletBalanceV5,
   WithdrawParamsV5,
   WithdrawalRecordV5,
-  SubAccountAllApiKeysResultV5,
-  GetSubAccountAllApiKeysParamsV5,
 } from './types';
 
 import { REST_CLIENT_TYPE_ENUM } from './util';

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -1379,7 +1379,7 @@ export class RestClientV5 extends BaseRestClient {
    *
    * DANGER: BE CAREFUL! The sub API key used to call this interface will be invalid immediately.
    */
-  deleteSubApiKey(params?: { apikey?: string; ): Promise<APIResponseV3WithTime<{}>> {
+  deleteSubApiKey(params?: { apikey?: string; }): Promise<APIResponseV3WithTime<{}>> {
     return this.postPrivate(
       '/v5/user/delete-sub-api',
       params,

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -142,6 +142,8 @@ import {
   WalletBalanceV5,
   WithdrawParamsV5,
   WithdrawalRecordV5,
+  SubAccountAllApiKeysResultV5,
+  GetSubAccountAllApiKeysParamsV5,
 } from './types';
 
 import { REST_CLIENT_TYPE_ENUM } from './util';
@@ -1296,6 +1298,17 @@ export class RestClientV5 extends BaseRestClient {
   }
 
   /**
+   * Query all api keys information of a sub UID.
+   */
+  getSubAccountAllApiKeys(
+    params: GetSubAccountAllApiKeysParamsV5,
+  ): Promise<
+    APIResponseV3WithTime<SubAccountAllApiKeysResultV5>
+  > {
+    return this.getPrivate('/v5/user/sub-apikeys', params);
+  }
+
+  /**
    * Froze sub uid. Use master user's api key only.
    *
    * TIP: The API key must have one of the permissions to be allowed to call the following API endpoint.
@@ -1361,12 +1374,16 @@ export class RestClientV5 extends BaseRestClient {
    *
    * TIP:
    * The API key must have one of the permissions to be allowed to call the following API endpoint.
-   * - sub API key: "Account Transfer"
+   * - sub API key: "Account Transfer", "Sub Member Transfer"
+   * - master API Key: "Account Transfer", "Sub Member Transfer", "Withdrawal"
    *
-   * DANGER: BE CAREFUL! The API key used to call this interface will be invalid immediately.
+   * DANGER: BE CAREFUL! The sub API key used to call this interface will be invalid immediately.
    */
-  deleteSubApiKey(): Promise<APIResponseV3WithTime<{}>> {
-    return this.postPrivate('/v5/user/delete-sub-api');
+  deleteSubApiKey(apikey?: string): Promise<APIResponseV3WithTime<{}>> {
+    return this.postPrivate(
+      '/v5/user/delete-sub-api',
+      apikey ? { apikey } : undefined,
+    );
   }
 
   /**

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -1379,10 +1379,10 @@ export class RestClientV5 extends BaseRestClient {
    *
    * DANGER: BE CAREFUL! The sub API key used to call this interface will be invalid immediately.
    */
-  deleteSubApiKey(apikey?: string): Promise<APIResponseV3WithTime<{}>> {
+  deleteSubApiKey(params?: { apikey?: string; ): Promise<APIResponseV3WithTime<{}>> {
     return this.postPrivate(
       '/v5/user/delete-sub-api',
-      apikey ? { apikey } : undefined,
+      params,
     );
   }
 

--- a/src/types/request/v5-user.ts
+++ b/src/types/request/v5-user.ts
@@ -39,3 +39,9 @@ export interface UpdateSubApiKeyUpdateParamsV5 {
 export interface DeleteSubMemberParamsV5 {
   subMemberId: string;
 }
+
+export interface GetSubAccountAllApiKeysParamsV5 {
+  subMemberId: string;
+  limit?: number;
+  cursor?: string;
+}

--- a/src/types/response/v5-user.ts
+++ b/src/types/response/v5-user.ts
@@ -34,7 +34,7 @@ export interface ApiKeyInfoV5 {
   secret: string;
   permissions: PermissionsV5;
   ips?: string[];
-  type: 1 | 2;
+  type: ApiKeyType;
   deadlineDay?: number;
   expiredAt?: string;
   createdAt: string;
@@ -56,4 +56,23 @@ export interface UpdateApiKeyResultV5 {
   secret: string;
   permissions: PermissionsV5;
   ips: string[];
+}
+
+export interface SubAccountAllApiKeysResultV5 {
+  result: {
+    id: string;
+    ips?: string[];
+    apiKey: string;
+    note: string;
+    status: number;
+    expiredAt?: string;
+    createdAt: string;
+    type: ApiKeyType;
+    permissions: PermissionsV5;
+    secret: string;
+    readOnly: 0 | 1;
+    deadlineDay?: number;
+    flag: string;
+  }[],
+  nextPageCursor: string;
 }

--- a/test/v5/private.read.test.ts
+++ b/test/v5/private.read.test.ts
@@ -273,6 +273,16 @@ describe('Private READ V5 REST API Endpoints', () => {
         ...successResponseObjectV3(),
       });
     });
+
+    it('getSubAccountAllApiKeys()', async () => {
+      expect(
+        await api.getSubAccountAllApiKeys({subMemberId: 'fakeid'})
+      ).toMatchObject({
+        // ...successResponseObjectV3(),
+        // Expected, since sub account ID is fake
+        retCode: API_ERROR_CODE.PARAMS_MISSING_OR_WRONG,
+      });
+    });
   });
 
   describe('Spot Leverage Token APIs', () => {


### PR DESCRIPTION
## Summary
1. Added new method `getSubAccountAllApiKeys`: https://bybit-exchange.github.io/docs/v5/user/list-sub-apikeys
2. Added parameter to `deleteSubApiKey`. "Delete Sub API Key" allows to delete sub account key using master key with “apikey” param: https://bybit-exchange.github.io/docs/v5/user/rm-sub-apikey