### PR TITLE
v3.10.5: Update `UpdateApiKeyParamsV5`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bybit-api",
-  "version": "3.10.4",
+  "version": "3.10.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bybit-api",
-      "version": "3.10.4",
+      "version": "3.10.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "3.10.4",
+  "version": "3.10.5",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -1345,10 +1345,11 @@ export class RestClientV5 extends BaseRestClient {
 
   /**
    * This endpoint modifies the settings of a sub API key.
-   * Use the API key pending to be modified to call the endpoint.
-   * Only the API key that calls this interface can be modified.
+   * Use the API key pending to be modified to call the endpoint or use master account api key to manage its sub account api key.
+   * The API key must have one of the below permissions in order to call this endpoint
    *
-   * The API key must own "Account Transfer" permission to be allowed to call this API endpoint.
+   *  - sub API key: "Account Transfer", "Sub Member Transfer"
+   *   - master API Key: "Account Transfer", "Sub Member Transfer", "Withdrawal"
    */
   updateSubApiKey(
     params: UpdateApiKeyParamsV5,

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -1349,7 +1349,7 @@ export class RestClientV5 extends BaseRestClient {
    * The API key must have one of the below permissions in order to call this endpoint
    *
    *  - sub API key: "Account Transfer", "Sub Member Transfer"
-   *   - master API Key: "Account Transfer", "Sub Member Transfer", "Withdrawal"
+   *  - master API Key: "Account Transfer", "Sub Member Transfer", "Withdrawal"
    */
   updateSubApiKey(
     params: UpdateApiKeyParamsV5,

--- a/src/types/request/v5-user.ts
+++ b/src/types/request/v5-user.ts
@@ -25,6 +25,7 @@ export interface CreateSubApiKeyParamsV5 {
 }
 
 export interface UpdateApiKeyParamsV5 {
+  apikey?: string;
   readOnly?: 0 | 1;
   ips?: string[];
   permissions: PermissionsV5;


### PR DESCRIPTION
## Summary
 - "Modify Sub API Key" API method supports updating of subaccount API Key using master API Key.
 - Updated method documentation
 - Updated `UpdateApiKeyParamsV5` params type
 - Reference https://bybit-exchange.github.io/docs/v5/user/modify-sub-apikey

