### PR TITLE
fix(): Comma/semicolon fix in params

### DIFF
--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -582,9 +582,9 @@ export class RestClientV5 extends BaseRestClient {
    *
    * Only for institutional clients!
    */
-  setDisconnectCancelAllWindowV2(params: { 
-    product: 'OPTION' | 'SPOT' | 'DERIVATIVES',
-    timeWindow: number,
+  setDisconnectCancelAllWindowV2(params: {
+    product: 'OPTION' | 'SPOT' | 'DERIVATIVES';
+    timeWindow: number;
   }): Promise<APIResponseV3<undefined>> {
     return this.postPrivate('/v5/order/disconnected-cancel-all', params);
   }


### PR DESCRIPTION
Fixed params that are object, types should have ; instead of , - check linter also to see if all is okay. 
