### PR TITLE
v3.10.18: feat(#368) add config for HTTP keep alive via axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bybit-api",
-  "version": "3.10.17",
+  "version": "3.10.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bybit-api",
-      "version": "3.10.17",
+      "version": "3.10.18",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "3.10.17",
+  "version": "3.10.18",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import axios, { AxiosRequestConfig, AxiosResponse, Method } from 'axios';
+import https from 'https';
 
 import {
   APIID,
@@ -136,6 +137,16 @@ export default abstract class BaseRestClient {
         'x-referer': APIID,
       },
     };
+
+    // If enabled, configure a https agent with keepAlive enabled
+    if (this.options.keepAlive) {
+      // For more advanced configuration, raise an issue on GitHub or use the "networkOptions"
+      // parameter to define a custom httpsAgent with the desired properties
+      this.globalRequestOptions.httpsAgent = new https.Agent({
+        keepAlive: true,
+        keepAliveMsecs: this.options.keepAliveMsecs,
+      });
+    }
 
     this.baseUrl = getRestBaseUrl(!!this.options.testnet, restOptions);
     this.key = this.options.key;

--- a/src/util/requestUtils.ts
+++ b/src/util/requestUtils.ts
@@ -29,6 +29,19 @@ export interface RestClientOptions {
    */
   enable_time_sync?: boolean;
 
+  /**
+   * Enable keep alive for REST API requests (via axios).
+   * See: https://github.com/tiagosiebler/bybit-api/issues/368
+   */
+  keepAlive?: boolean;
+
+  /**
+   * When using HTTP KeepAlive, how often to send TCP KeepAlive packets over sockets being kept alive. Default = 1000.
+   * Only relevant if keepAlive is set to true.
+   * Default: 1000 (defaults comes from https agent)
+   */
+  keepAliveMsecs?: number;
+
   /** How often to sync time drift with bybit servers */
   sync_interval_ms?: number | string;
 


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->
Simple feature to configure HTTPS keep alive via axios, without messing with the axios config.

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
Resolves #368 