### PR TITLE
fix(): adjusted type definitions for instruments endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "3.10.28",
+  "version": "3.10.29",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/response/v5-market.ts
+++ b/src/types/response/v5-market.ts
@@ -75,6 +75,10 @@ export interface LinearInverseInstrumentInfoV5 {
   copyTrading: CopyTradingV5;
   upperFundingRate: string;
   lowerFundingRate: string;
+  riskParameters: {
+    priceLimitRatioX: string;
+    priceLimitRatioY: string;
+  };
   isPreListing: boolean;
   preListingInfo: {
     curAuctionPhase: string;
@@ -97,7 +101,7 @@ export interface OptionInstrumentInfoV5 {
   status: InstrumentStatusV5;
   baseCoin: string;
   quoteCoin: string;
-  settleCoin: boolean;
+  settleCoin: string;
   launchTime: string;
   deliveryTime: string;
   deliveryFeeRate: string;
@@ -120,6 +124,7 @@ export interface SpotInstrumentInfoV5 {
   innovation: '0' | '1';
   status: InstrumentStatusV5;
   marginTrading: MarginTradingV5;
+  stTag: '0' | '1';
   lotSizeFilter: {
     basePrecision: string;
     quotePrecision: string;
@@ -132,8 +137,8 @@ export interface SpotInstrumentInfoV5 {
     tickSize: string;
   };
   riskParameters: {
-    limitParameter: string;
-    marketParameter: string;
+    priceLimitRatioX: string;
+    priceLimitRatioY: string;
   };
 }
 


### PR DESCRIPTION
## Summary
Adjusted type definitions for `LinearInverseInstrumentInfoV5` and `SpotInstrumentInfoV5` to align with the official documentation. Added missing fields and corrected incorrect types.

Fixes #405

## Additional Information
- No breaking changes introduced.
- Fields added to match the official API documentation:
  - `riskParameters` with `priceLimitRatioX` and `priceLimitRatioY`.
  - `stTag` for `SpotInstrumentInfoV5`.