### PR TITLE
feat(3.10.33): Updated return types for getSubDepositAddress, createUniversalTransfer and createInternalTransfer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bybit-api",
-  "version": "3.10.32",
+  "version": "3.10.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bybit-api",
-      "version": "3.10.32",
+      "version": "3.10.33",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "3.10.32",
+  "version": "3.10.33",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -57,7 +57,7 @@ import {
   DeleteSubMemberParamsV5,
   DeliveryPriceV5,
   DeliveryRecordV5,
-  DepositAddressResultV5,
+  DepositAddressChainV5,
   DepositRecordV5,
   ExchangeBrokerAccountInfoV5,
   ExchangeBrokerEarningResultV5,
@@ -1305,7 +1305,7 @@ export class RestClientV5 extends BaseRestClient {
     amount: string,
     fromAccountType: AccountTypeV5,
     toAccountType: AccountTypeV5,
-  ): Promise<APIResponseV3WithTime<{ transferId: string }>> {
+  ): Promise<APIResponseV3WithTime<{ transferId: string; status: string }>> {
     return this.postPrivate('/v5/asset/transfer/inter-transfer', {
       transferId,
       coin,
@@ -1365,7 +1365,7 @@ export class RestClientV5 extends BaseRestClient {
    */
   createUniversalTransfer(
     params: UniversalTransferParamsV5,
-  ): Promise<APIResponseV3WithTime<{ transferId: string }>> {
+  ): Promise<APIResponseV3WithTime<{ transferId: string; status: string }>> {
     return this.postPrivate('/v5/asset/transfer/universal-transfer', params);
   }
 
@@ -1464,7 +1464,12 @@ export class RestClientV5 extends BaseRestClient {
   getMasterDepositAddress(
     coin: string,
     chainType?: string,
-  ): Promise<APIResponseV3WithTime<DepositAddressResultV5>> {
+  ): Promise<
+    APIResponseV3WithTime<{
+      coin: string;
+      chains: DepositAddressChainV5[];
+    }>
+  > {
     return this.getPrivate('/v5/asset/deposit/query-address', {
       coin,
       chainType,
@@ -1478,7 +1483,12 @@ export class RestClientV5 extends BaseRestClient {
     coin: string,
     chainType: string,
     subMemberId: string,
-  ): Promise<APIResponseV3WithTime<DepositAddressResultV5>> {
+  ): Promise<
+    APIResponseV3WithTime<{
+      coin: string;
+      chains: DepositAddressChainV5;
+    }>
+  > {
     return this.getPrivate('/v5/asset/deposit/query-sub-member-address', {
       coin,
       chainType,
@@ -1488,6 +1498,7 @@ export class RestClientV5 extends BaseRestClient {
 
   /**
    * Query the deposit address information of SUB account.
+   * @deprecated Duplicate endpoint - Use getSubDepositAddress() instead
    *
    * CAUTION
    * Can use master UID's api key only
@@ -1496,7 +1507,12 @@ export class RestClientV5 extends BaseRestClient {
     coin: string,
     chainType: string,
     subMemberId: string,
-  ): Promise<APIResponseV3<DepositAddressResultV5>> {
+  ): Promise<
+    APIResponseV3<{
+      coin: string;
+      chains: DepositAddressChainV5;
+    }>
+  > {
     return this.getPrivate('/v5/asset/deposit/query-sub-member-address', {
       coin,
       chainType,


### PR DESCRIPTION
Incorrect return type in getSubDepositAddress
Now export interface DepositAddressResultV5 { coin: string; chains: DepositAddressChainV5[]; }
Expected export interface DepositAddressResultV5 { coin: string; chains: DepositAddressChainV5; }
In createUniversalTransfer and createInternalTransfer, the return type field "status" was missed.
Now { transferId: string; }
Expected { transferId: string; status: string; }

fixes #417