### PR TITLE
fix(v3.11.0): ensure private GET requests use serialised/encoded params appended to URL. Update slippage tolerance type to optional.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bybit-api",
-  "version": "3.10.34",
+  "version": "3.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bybit-api",
-      "version": "3.10.34",
+      "version": "3.11.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "3.10.34",
+  "version": "3.11.0",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/request/v5-trade.ts
+++ b/src/types/request/v5-trade.ts
@@ -18,8 +18,8 @@ export interface OrderParamsV5 {
   orderType: OrderTypeV5;
   qty: string;
   marketUnit?: 'baseCoin' | 'quoteCoin';
-  slippageToleranceType: string;
-  slippageTolerance: string;
+  slippageToleranceType?: string;
+  slippageTolerance?: string;
   price?: string;
   triggerDirection?: 1 | 2;
   orderFilter?: OrderFilterV5;

--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -67,6 +67,7 @@ interface SignedRequest<T> {
 interface UnsignedRequest<T> {
   originalParams: T;
   paramsWithSign: T;
+  serializedParams: string;
   sign?: string;
   timestamp?: number;
   recvWindow?: number;
@@ -285,7 +286,9 @@ export default abstract class BaseRestClient {
         return {
           ...options,
           headers,
-          params: signResult.originalParams,
+          url: signResult.serializedParams
+            ? options.url + '?' + signResult.serializedParams
+            : options.url,
         };
       }
 

--- a/test/v5/private.read.test.ts
+++ b/test/v5/private.read.test.ts
@@ -188,7 +188,35 @@ describe('Private READ V5 REST API Endpoints', () => {
           accountType: accountType,
           coin: settleCoin,
         }),
-      ).toMatchObject({ ...successResponseObjectV3() });
+      ).toMatchObject({
+        ...successResponseObjectV3(),
+        // retMsg: '',
+      });
+    });
+
+    it('getAllCoinsBalance() unified with one symbol', async () => {
+      const result = await api.getAllCoinsBalance({
+        accountType: 'UNIFIED',
+        coin: 'USDT',
+      });
+
+      if (result.retCode !== 0) {
+        console.error(expect.getState().currentTestName, 'exception: ', result);
+      }
+
+      expect(result).toMatchObject({ ...successResponseObjectV3() });
+    });
+
+    it('getAllCoinsBalance() unified with multiple symbols', async () => {
+      const result = await api.getAllCoinsBalance({
+        accountType: 'UNIFIED',
+        coin: 'USDT,ETH',
+      });
+
+      if (result.retCode !== 0) {
+        console.error(expect.getState().currentTestName, 'exception: ', result);
+      }
+      expect(result).toMatchObject({ ...successResponseObjectV3() });
     });
 
     it('getTransferableCoinList()', async () => {


### PR DESCRIPTION
fix(v3.11.0): ensure private GET requests use serialised/encoded params appended to URL. Update slippage tolerance type to optional.

Fixes sign error when parameter for GET API call contains symbols (comma). 

## Summary
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
