### PR TITLE
fix(types): change response v5-asset CoinInfoV5.name

### DIFF
--- a/src/types/response/v5-asset.ts
+++ b/src/types/response/v5-asset.ts
@@ -146,7 +146,7 @@ export interface DepositAddressResultV5 {
 }
 
 export interface CoinInfoV5 {
-  name: number;
+  name: string;
   coin: string;
   remainAmount: string;
   chains: {


### PR DESCRIPTION
Updated response v5-asset CoinInfoV5.name from number to string to match Binance API response format.
Prevents potential type issues when mapping coin data.