### PR TITLE
feat: add 'spot' category support to batchCancelOrders method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bybit-api",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bybit-api",
-      "version": "4.1.10",
+      "version": "4.1.11",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/rest-client-v5.ts
+++ b/src/rest-client-v5.ts
@@ -852,14 +852,14 @@ export class RestClientV5 extends BaseRestClient {
 
   /**
    * This endpoint allows you to cancel more than one open order in a single request.
-   * Covers: Option (UTA, UTA Pro) / USDT Perpetual, UDSC Perpetual, USDC Futures (UTA Pro)
+   * Covers: Spot, Option (UTA, UTA Pro) / USDT Perpetual, UDSC Perpetual, USDC Futures (UTA Pro)
    *
    * You must specify orderId or orderLinkId. If orderId and orderLinkId is not matched, the system will process orderId first.
    *
    * You can cancel unfilled or partially filled orders. A maximum of 20 orders can be cancelled per request.
    */
   batchCancelOrders(
-    category: 'option' | 'linear',
+    category: 'spot' | 'option' | 'linear',
     orders: BatchCancelOrderParamsV5[],
   ): Promise<
     APIResponseV3WithTime<


### PR DESCRIPTION
- Updated category parameter to include 'spot' alongside 'option' and 'linear'
- Aligns with Bybit API v5 specification which supports spot category for batch cancel operations
- Bump version to 4.1.11

## Summary
This PR adds support for the 'spot' category in the `batchCancelOrders` method. The Bybit API v5 `/v5/order/cancel-batch` endpoint supports spot trading alongside option and linear categories, but the TypeScript interface was missing this category type.

## Additional Information
- **No breaking changes**: This is an additive change that expands the accepted category types
- **API alignment**: Brings the TypeScript interface in line with the actual Bybit API v5 capabilities
- **Backward compatibility**: Existing code using 'option' or 'linear' will continue to work unchanged

## PR Checklist
As part of the PR, make sure you have:
- [x] No breaking changes / documented all breaking changes clearly.
- [x] Updated & checked that all tests pass.
- [ ] Updated the endpoint map (optional, if you know how).
- [x] Increased the version number in the package.json
- [x] Checked `npm install` runs without issue.
- [x] Included the package-lock.json, if it changed after npm install
- [x] Checked `npm run build` runs without issue.