### PR TITLE
feat(#437, v4.3.0): add config to throw REST API exceptions automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ privaterepotracker
 restClientRegex.ts
 repomix.sh
 
+examples/ignored

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bybit-api",
-  "version": "4.2.7",
+  "version": "4.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bybit-api",
-      "version": "4.2.7",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybit-api",
-  "version": "4.2.7",
+  "version": "4.3.0",
   "description": "Complete & robust Node.js SDK for Bybit's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -345,10 +345,16 @@ export default abstract class BaseRestClient {
               )
             : undefined;
 
-          return {
+          const result = {
             rateLimitApi: perAPIRateLimits,
             ...response.data,
           };
+
+          if (this.options.throwExceptions && result.retCode !== 0) {
+            throw result;
+          }
+
+          return result;
         }
 
         throw response;
@@ -366,7 +372,7 @@ export default abstract class BaseRestClient {
 
     // Something happened in setting up the request that triggered an Error
     if (!e.response) {
-      if (!e.request) {
+      if (!e.request && e.message) {
         throw e.message;
       }
 

--- a/src/util/requestUtils.ts
+++ b/src/util/requestUtils.ts
@@ -74,6 +74,9 @@ export interface RestClientOptions {
   /** Default: false. Enable to throw error if rate limit parser fails */
   throwOnFailedRateLimitParse?: boolean;
 
+  /** Default: false. Enable to automatically throw responses for failed REST API requests */
+  throwExceptions?: boolean;
+
   /**
    * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
    *


### PR DESCRIPTION
## Summary

Disabled by default to prevent any breaking changes. Enable it by passing this boolean in the REST client constructor:
```typescript
const client = new RestClientV5({
  key: key,
  secret: secret,
  throwExceptions: true,
});
```

Any retCode !== 0 response will be thrown in full, if enabled.
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

## PR Checklist

As part of the PR, make sure you have:
- [ ] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Run llms.txt generator (optional, if you know how).
